### PR TITLE
Add PHP quality tools configuration

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,24 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([
+        __DIR__.'/administrator/src',
+        __DIR__.'/site/src',
+        __DIR__.'/api/src',
+        __DIR__.'/modules/mod_alfa_cart/src',
+        __DIR__.'/modules/mod_alfa_search/src',
+        __DIR__.'/plugins/alfa-payments/revolut/src',
+        __DIR__.'/plugins/alfa-payments/viva/src',
+        __DIR__.'/plugins/alfa-payments/standard/src',
+        __DIR__.'/plugins/alfa-shipments/boxnow/src',
+        __DIR__.'/plugins/alfa-shipments/standard/src',
+        __DIR__.'/plugins/alfa-fields/text/src',
+        __DIR__.'/plugins/alfa-fields/textarea/src',
+    ]);
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+    ])
+    ->setFinder($finder);

--- a/README.md
+++ b/README.md
@@ -31,8 +31,32 @@ To contribute:
     Commit your changes (git commit -m 'Add some feature').
     Push to the branch (git push origin feature-branch).
     Open a Pull Request.
-    
+
     or you can be a part of our team by getting in touch with us.
+
+## Development Tools
+
+This project uses Composer to manage development utilities such as
+[PHPStan](https://phpstan.org/) and
+[PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer).
+
+1. Install the dependencies:
+
+   ```bash
+   composer install
+   ```
+
+2. Run a static analysis:
+
+   ```bash
+   composer phpstan
+   ```
+
+3. Check the coding style:
+
+   ```bash
+   composer phpcsfixer
+   ```
 
 
 Developer Contact

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "easylogic/alfa-commerce",
+    "type": "project",
+    "description": "Pre-alpha eCommerce solution for Joomla",
+    "autoload": {
+        "psr-4": {
+            "Alfa\\Component\\Alfa\\Administrator\\": "administrator/src/",
+            "Alfa\\Component\\Alfa\\Site\\": "site/src/",
+            "Alfa\\Component\\Alfa\\Api\\": "api/src/",
+            "Alfa\\Module\\AlfaCart\\": "modules/mod_alfa_cart/src/",
+            "Alfa\\Module\\AlfaSearch\\": "modules/mod_alfa_search/src/",
+            "Joomla\\Plugin\\AlfaPayments\\Revolut\\": "plugins/alfa-payments/revolut/src/",
+            "Joomla\\Plugin\\AlfaPayments\\Standard\\": "plugins/alfa-payments/standard/src/",
+            "Joomla\\Plugin\\AlfaPayments\\Viva\\": "plugins/alfa-payments/viva/src/",
+            "Joomla\\Plugin\\AlfaShipments\\Boxnow\\": "plugins/alfa-shipments/boxnow/src/",
+            "Joomla\\Plugin\\AlfaShipments\\Standard\\": "plugins/alfa-shipments/standard/src/",
+            "Joomla\\Plugin\\AlfaFields\\Text\\": "plugins/alfa-fields/text/src/",
+            "Joomla\\Plugin\\AlfaFields\\Textarea\\": "plugins/alfa-fields/textarea/src/"
+        }
+    },
+    "require": {},
+    "require-dev": {
+        "phpstan/phpstan": "^1.10",
+        "friendsofphp/php-cs-fixer": "^3.0"
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse",
+        "phpcsfixer": "php-cs-fixer fix --dry-run"
+    }
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,28 @@
+parameters:
+    level: 5
+    paths:
+        - administrator/src
+        - site/src
+        - api/src
+        - modules/mod_alfa_cart/src
+        - modules/mod_alfa_search/src
+        - plugins/alfa-payments/revolut/src
+        - plugins/alfa-payments/viva/src
+        - plugins/alfa-payments/standard/src
+        - plugins/alfa-shipments/boxnow/src
+        - plugins/alfa-shipments/standard/src
+        - plugins/alfa-fields/text/src
+        - plugins/alfa-fields/textarea/src
+    autoload_directories:
+        - administrator/src
+        - site/src
+        - api/src
+        - modules/mod_alfa_cart/src
+        - modules/mod_alfa_search/src
+        - plugins/alfa-payments/revolut/src
+        - plugins/alfa-payments/viva/src
+        - plugins/alfa-payments/standard/src
+        - plugins/alfa-shipments/boxnow/src
+        - plugins/alfa-shipments/standard/src
+        - plugins/alfa-fields/text/src
+        - plugins/alfa-fields/textarea/src


### PR DESCRIPTION
## Summary
- set up Composer for PHP tools and namespaces
- configure phpstan and php-cs-fixer
- document how to run quality tools in README

## Testing
- `composer install` *(fails: composer not found)*
- `composer phpstan` *(fails: composer not found)*
- `composer phpcsfixer` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf15ddec48328822388c87e13c39a