### PR TITLE
Add contributor workflow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,45 @@ The Alfa-Commerce API empowers developers to seamlessly integrate eCommerce func
 
 Contributions are what make the open-source community such an amazing place to learn, inspire, and create. We welcome contributions from everyone, especially those excited to help alfa-commerce grow.
 
-To contribute:
+### Step-by-Step Contribution Guide
 
-    Fork the repository.
-    Create a branch derived from developer branch for your feature or bugfix.
-    Commit your changes (git commit -m 'Add some feature').
-    Push to the branch (git push origin feature-branch).
-    Open a Pull Request.
+1. **Fork** the repository on GitHub and **clone** your fork:
 
-    or you can be a part of our team by getting in touch with us.
+   ```bash
+   git clone https://github.com/<your-username>/Alfa-Commerce.git
+   cd Alfa-Commerce
+   ```
+
+2. **Install** the project dependencies (this sets up PHPStan and PHP-CS-Fixer):
+
+   ```bash
+   composer install
+   ```
+
+3. **Create** a feature branch based on the developer branch (`work`):
+
+   ```bash
+   git checkout -b my-feature-branch origin/work
+   ```
+
+4. **Run** the static analysis and coding style checks:
+
+   ```bash
+   composer phpstan
+   composer phpcsfixer
+   ```
+
+5. **Make** your changes, **commit**, and **push** the branch:
+
+   ```bash
+   git add .
+   git commit -m "Describe your change"
+   git push origin my-feature-branch
+   ```
+
+6. **Open a Pull Request**. The CI workflow will automatically run the same PHPStan and PHP-CS-Fixer checks. Address any issues reported by the CI before requesting a review.
+
+You can also get in touch with the team if you want to be a part of the project.
 
 ## Development Tools
 
@@ -57,6 +87,10 @@ This project uses Composer to manage development utilities such as
    ```bash
    composer phpcsfixer
    ```
+
+## Continuous Integration
+
+GitHub Actions run the same PHPStan and PHP-CS-Fixer checks on each push and pull request. The workflow is defined in `.github/workflows/ci.yml` and helps keep the codebase consistent. Make sure the local checks pass before opening a pull request so the CI succeeds.
 
 
 Developer Contact


### PR DESCRIPTION
## Summary
- expand the `Contributing` section with step-by-step guide
- describe CI checks for PHPStan and PHP-CS-Fixer

## Testing
- `composer install --no-progress` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf6459fec8328ae29ca7f534664eb