### PR TITLE
Configure PHPStan with Joomla stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,20 @@
     "require": {},
     "require-dev": {
         "phpstan/phpstan": "^1.10",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "joomla/joomla-cms": "dev-5.3-dev"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/joomla/joomla-cms"
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
-        "phpstan": "phpstan analyse",
-        "phpcsfixer": "php-cs-fixer fix --dry-run"
+        "phpstan": "phpstan analyse --memory-limit=-1",
+        "phpcsfixer": "php-cs-fixer fix --dry-run",
+        "phpcsfixer:fix": "php-cs-fixer fix"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,10 @@
+includes:
+    - vendor/joomla/joomla-cms/build/phpstan/phpstan.neon
+
 parameters:
     level: 5
+    bootstrapFiles:
+        - vendor/joomla/joomla-cms/includes/constants.php
     paths:
         - administrator/src
         - site/src


### PR DESCRIPTION
## Summary
- add Joomla CMS repository to Composer config so dev versions can be installed
- allow dev dependencies by setting minimum-stability
- specify the Joomla dev branch accurately

## Testing
- `composer install --no-interaction` *(fails: composer not found)*
- `vendor/bin/phpstan --version` *(fails: No such file or directory)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684c0fbce71c8328894170854d9ce364