### PR TITLE
Remove PHPStan from CI and composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,5 @@ jobs:
           tools: composer
       - name: Install dependencies
         run: composer install --no-progress
-      - name: Run PHPStan
-        run: composer phpstan
       - name: Run PHP CS Fixer
         run: composer phpcsfixer

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Contributions are what make the open-source community such an amazing place to l
    cd Alfa-Commerce
    ```
 
-2. **Install** the project dependencies (this sets up PHPStan and PHP-CS-Fixer):
+2. **Install** the project dependencies (this sets up PHP-CS-Fixer):
 
    ```bash
    composer install
@@ -45,10 +45,9 @@ Contributions are what make the open-source community such an amazing place to l
    git checkout -b my-feature-branch origin/developer
    ```
 
-4. **Run** the static analysis and coding style checks:
+4. **Run** the coding style checks:
 
    ```bash
-   composer phpstan
    composer phpcsfixer
    ```
 
@@ -60,14 +59,13 @@ Contributions are what make the open-source community such an amazing place to l
    git push origin my-feature-branch
    ```
 
-6. **Open a Pull Request**. The CI workflow will automatically run the same PHPStan and PHP-CS-Fixer checks. Address any issues reported by the CI before requesting a review.
+6. **Open a Pull Request**. The CI workflow will automatically run the PHP-CS-Fixer checks. Address any issues reported by the CI before requesting a review.
 
 You can also get in touch with the team if you want to be a part of the project.
 
 ## Development Tools
 
 This project uses Composer to manage development utilities such as
-[PHPStan](https://phpstan.org/) and
 [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer).
 
 1. Install the dependencies:
@@ -76,13 +74,7 @@ This project uses Composer to manage development utilities such as
    composer install
    ```
 
-2. Run a static analysis:
-
-   ```bash
-   composer phpstan
-   ```
-
-3. Check the coding style:
+2. Check the coding style:
 
    ```bash
    composer phpcsfixer
@@ -90,7 +82,7 @@ This project uses Composer to manage development utilities such as
 
 ## Continuous Integration
 
-GitHub Actions run the same PHPStan and PHP-CS-Fixer checks on each push and pull request. The workflow is defined in `.github/workflows/ci.yml` and helps keep the codebase consistent. Make sure the local checks pass before opening a pull request so the CI succeeds.
+GitHub Actions run the PHP-CS-Fixer checks on each push and pull request. The workflow is defined in `.github/workflows/ci.yml` and helps keep the codebase consistent. Make sure the local checks pass before opening a pull request so the CI succeeds.
 
 
 Developer Contact

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,9 @@
     },
     "require": {},
     "require-dev": {
-        "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^3.0"
     },
     "scripts": {
-        "phpstan": "phpstan analyse --memory-limit=-1",
         "phpcsfixer": "php-cs-fixer fix --dry-run",
         "phpcsfixer:fix": "php-cs-fixer fix"
     }


### PR DESCRIPTION
## Summary
- remove PHPStan from dev requirements and composer scripts
- update contribution docs to only mention PHP-CS-Fixer
- run only PHP-CS-Fixer in CI workflow

## Testing
- `composer phpcsfixer` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684de98684008328911a59893249b4ce