### PR TITLE
Update PHP version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up PHP with Composer
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           tools: composer
       - name: Install dependencies
         run: composer install --no-progress

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ While we are still in the pre-alpha phase, the core is being actively built and 
     Go to main branch
     Download the whole zip
     Install it in joomla.
+    Ensure you have **PHP 8.3** or later installed.
 
 🌐 API Integration with Postman
 
@@ -37,6 +38,10 @@ Contributions are what make the open-source community such an amazing place to l
 
    ```bash
    composer install
+
+   # Commit the generated composer.lock file
+   git add composer.lock
+   git commit -m "Add composer.lock"
    ```
 
 3. **Create** a feature branch based on the developer branch (`developer`):

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
             "Joomla\\Plugin\\AlfaFields\\Textarea\\": "plugins/alfa-fields/textarea/src/"
         }
     },
-    "require": {},
+    "require": {
+        "php": "^8.3"
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0"
     },


### PR DESCRIPTION
## Summary
- require PHP 8.3 in `composer.json`
- update CI workflow to run PHP 8.3
- document PHP version and committing `composer.lock` in README

## Testing
- `composer update` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684df23f4b0c8328940b7f7fdf266abb