### PR TITLE
Add GitHub community standards files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Report a bug to help us improve Alfa Commerce
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+
+What actually happened instead.
+
+## Screenshots
+
+If applicable, add screenshots to help explain the problem.
+
+## Environment
+
+- **Joomla Version:** [e.g., 4.4.1 or 5.1.0]
+- **PHP Version:** [e.g., 8.2]
+- **MySQL Version:** [e.g., 8.0]
+- **Alfa Commerce Version:** [e.g., pre-alpha]
+- **Browser:** [e.g., Chrome 120, Firefox 121]
+- **Operating System:** [e.g., Windows 11, macOS 14]
+
+## Additional Context
+
+Add any other context about the problem here (error logs, server configuration, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for Alfa Commerce
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Is your feature request related to a problem?
+
+A clear and concise description of what the problem is. Example: "I'm always frustrated when..."
+
+## Describe the Solution You'd Like
+
+A clear and concise description of what you want to happen.
+
+## Describe Alternatives You've Considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Use Case
+
+Describe the use case for this feature. Who would benefit from it and how?
+
+## Additional Context
+
+Add any other context, mockups, or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Description
+
+Brief description of the changes in this PR.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactoring (no functional changes)
+- [ ] Documentation update
+
+## Related Issue
+
+Fixes # (issue number)
+
+## How Has This Been Tested?
+
+Describe the tests you ran to verify your changes:
+
+- [ ] Tested on Joomla 4.x
+- [ ] Tested on Joomla 5.x
+- [ ] Tested frontend functionality
+- [ ] Tested backend admin functionality
+
+## Checklist
+
+- [ ] My code follows the project's coding standards (PSR-12)
+- [ ] I have tested my changes locally on a Joomla installation
+- [ ] My changes do not introduce new warnings or errors
+- [ ] I have added comments where the logic is not self-evident
+- [ ] My branch is based on the `developer` branch
+- [ ] I have not committed any secrets, API keys, or credentials

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,48 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a welcoming and positive experience for everyone, regardless of
+background or identity.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive feedback
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- Trolling, insulting or derogatory comments, and personal attacks
+- Public or private harassment of any kind
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, including GitHub
+issues, pull requests, discussions, and any other project communication channels.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project team at
+**info@easylogic.gr**. All complaints will be reviewed and investigated promptly
+and fairly. The project team is obligated to maintain confidentiality with regard
+to the reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Pre-alpha (current) | Yes |
+
+## Reporting a Vulnerability
+
+We take security seriously at Alfa Commerce. If you discover a security vulnerability, please report it responsibly.
+
+### How to Report
+
+1. **Do NOT open a public GitHub issue** for security vulnerabilities
+2. Send an email to **info@easylogic.gr** with the subject line: `[SECURITY] Alfa Commerce Vulnerability Report`
+3. Include the following information:
+   - Description of the vulnerability
+   - Steps to reproduce the issue
+   - Potential impact
+   - Suggested fix (if any)
+
+### What to Expect
+
+- **Acknowledgment:** We will acknowledge receipt of your report within 48 hours
+- **Assessment:** We will investigate and assess the vulnerability within 7 days
+- **Resolution:** We aim to release a fix within 30 days of confirming the vulnerability
+- **Credit:** We will credit reporters in the release notes (unless you prefer to remain anonymous)
+
+### Scope
+
+The following are in scope for security reports:
+
+- SQL injection
+- Cross-site scripting (XSS)
+- Cross-site request forgery (CSRF)
+- Authentication or authorization bypasses
+- Remote code execution
+- Sensitive data exposure
+- Payment processing vulnerabilities
+
+### Out of Scope
+
+- Vulnerabilities in Joomla core (report these to the Joomla Security Strike Team)
+- Denial of service attacks
+- Social engineering
+- Issues in third-party dependencies (report these to the respective maintainers)
+
+## Security Best Practices for Contributors
+
+- Always use Joomla's `DatabaseDriver` with parameterized queries — never concatenate user input into SQL
+- Sanitize all user input using Joomla's `InputFilter`
+- Use CSRF tokens for all form submissions
+- Never commit secrets, API keys, or credentials to the repository
+- Follow the principle of least privilege for database operations
+
+## Contact
+
+- **Email:** info@easylogic.gr
+- **Website:** [easylogic.gr](https://easylogic.gr)


### PR DESCRIPTION
## Summary
- Added **Code of Conduct** (Contributor Covenant v2.1)
- Added **Security Policy** with vulnerability reporting guidelines
- Added **Issue Templates** (bug report and feature request)
- Added **Pull Request Template** with checklist

## Notes
Two items require manual action on GitHub:
- **Repository description** — set in Settings > General
- **Content reports** — enable in Settings > Moderation