### PR TITLE
Release 1.0.6

### DIFF
--- a/alfa.xml
+++ b/alfa.xml
@@ -7,7 +7,7 @@
     <author>Agamemnon Fakas</author>
     <authorEmail>info@easylogic.gr</authorEmail>
     <authorUrl>https://easylogic.gr</authorUrl>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <description>The smartest,fastest and easiest ecommerce solution for companies developed with love by Easylogic.</description>
     <namespace path="src">Alfa\Component\Alfa</namespace>
 

--- a/changelog.xml
+++ b/changelog.xml
@@ -3,6 +3,16 @@
     <changelog>
         <element>com_alfa</element>
         <type>component</type>
+        <version>1.0.6</version>
+
+        <fix>
+            <item>File-integrity verification no longer flags optional (non-en-GB) language packs as drift — installs without a given language pack now verify cleanly.</item>
+        </fix>
+    </changelog>
+
+    <changelog>
+        <element>com_alfa</element>
+        <type>component</type>
         <version>1.0.5</version>
 
         <addition>


### PR DESCRIPTION
Promotes developer to main for 1.0.6 (main: 1.0.5 → 1.0.6). Integrity verification now ignores optional (non-en-GB) language packs, so installs without a given language pack verify cleanly. Merge commit preserves contributors.