### PR TITLE
Sync to main: Joomla 5/6/7, plain changelog, comment tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alfa Commerce
 
-A full-featured eCommerce component for Joomla 4.x / 5.x / 6.x, developed by [Easylogic](https://easylogic.gr).
+A full-featured eCommerce component for Joomla 5.x / 6.x / 7.x, developed by [Easylogic](https://easylogic.gr).
 
 > **Status:** Beta — the core is being actively built and tested.
 
@@ -20,7 +20,7 @@ A full-featured eCommerce component for Joomla 4.x / 5.x / 6.x, developed by [Ea
 ## Requirements
 
 - PHP 8.2+
-- Joomla 4.x, 5.x or 6.x
+- Joomla 5.x, 6.x or 7.x
 - MySQL (utf8mb4)
 
 ## Installation

--- a/administrator/layouts/notifications/panel.php
+++ b/administrator/layouts/notifications/panel.php
@@ -9,7 +9,7 @@
  * The panel region of the badge component — the `.alfa-notify-dropdown` itself (the JS
  * moves nothing; it's position:fixed and the JS only sets its coordinates). `data-region`
  * lets the JS target it; `data-open` + the `show` class carry the open state so a refresh
- * restores it. Visibility is already filtered upstream; here we only decide per row
+ * restores it. Visibility is already filtered upstream; this layout only decides, per row,
  * whether to show the link (url-access). Styling: notifications.css.
  *
  * @var array $displayData  ['items' => object[], 'is_open' => bool]

--- a/changelog.xml
+++ b/changelog.xml
@@ -34,6 +34,8 @@
         <version>1.0.4</version>
 
         <addition>
+            <item>Multilingual support across the catalog: per-language content (names, aliases and metadata) for categories, manufacturers, items and more.</item>
+            <item>Unique form fields: enforce unique values on custom form field options.</item>
             <item>Items list (back end): new Categories and Manufacturers columns showing every related entry per item, with translated names.</item>
             <item>Items list (back end): working Categories and Manufacturers filters (multi-select) in the search toolbar.</item>
             <item>Order statuses: role-flag taxonomy (Initial / Cancellation / Completed) replacing the legacy is_default column, with save/publish/delete invariants.</item>

--- a/changelog.xml
+++ b/changelog.xml
@@ -16,29 +16,14 @@
         <version>1.0.5</version>
 
         <addition>
+            <item>Multilingual catalog — translate categories, manufacturers, items and more, each in its own language.</item>
+            <item>Order statuses with customisable status-change emails for customers and admins.</item>
+            <item>Customisable email layouts for order-status notifications.</item>
+            <item>Unique values for custom form field options.</item>
+            <item>Categories and Manufacturers columns and filters on the Items list.</item>
             <item>Notification centre in the admin — a toolbar bell with a quick panel and a full history.</item>
             <item>File-integrity check (Tools &gt; Security) that verifies your installed files against the official release.</item>
             <item>One-click export of the component as an installable package.</item>
-        </addition>
-
-        <fix>
-            <item>Notification sort options now show translated labels instead of raw keys.</item>
-            <item>The notification count badge now shows and hides correctly.</item>
-            <item>Tools now appears as the last item in the component menu.</item>
-        </fix>
-    </changelog>
-
-    <changelog>
-        <element>com_alfa</element>
-        <type>component</type>
-        <version>1.0.4</version>
-
-        <addition>
-            <item>Multilingual catalog — translate categories, manufacturers, items and more, each in its own language.</item>
-            <item>Unique values for custom form field options.</item>
-            <item>Categories and Manufacturers columns and filters on the Items list.</item>
-            <item>Order statuses with customisable status-change emails for customers and admins.</item>
-            <item>Customisable email layouts for order-status notifications.</item>
             <item>Automatic updates delivered through Joomla's update manager.</item>
         </addition>
 
@@ -46,6 +31,9 @@
             <item>Custom form field groups now work correctly on a fresh install.</item>
             <item>The database Fix tool (System &gt; Database) now recognises the component.</item>
             <item>Order-status email "Restore defaults" now fills every section, not just the intro.</item>
+            <item>Notification sort options now show translated labels instead of raw keys.</item>
+            <item>The notification count badge now shows and hides correctly.</item>
+            <item>Tools now appears as the last item in the component menu.</item>
         </fix>
     </changelog>
 </changelogs>

--- a/changelog.xml
+++ b/changelog.xml
@@ -47,9 +47,5 @@
             <item>The database Fix tool (System &gt; Database) now recognises the component.</item>
             <item>Order-status email "Restore defaults" now fills every section, not just the intro.</item>
         </fix>
-
-        <note>
-            <item>Existing sites can add the new form-field-groups table via System &gt; Database &gt; Fix; fresh installs get it automatically.</item>
-        </note>
     </changelog>
 </changelogs>

--- a/changelog.xml
+++ b/changelog.xml
@@ -6,7 +6,7 @@
         <version>1.0.6</version>
 
         <fix>
-            <item>File-integrity verification no longer flags optional (non-en-GB) language packs as drift — installs without a given language pack now verify cleanly.</item>
+            <item>Installs without a given language pack are no longer flagged by the file-integrity check.</item>
         </fix>
     </changelog>
 
@@ -16,15 +16,15 @@
         <version>1.0.5</version>
 
         <addition>
-            <item>Backend notification centre: a toolbar bell with a quick panel and a full history view, backed by a generic notification store that any part of the component (or the API) can push into.</item>
-            <item>File-integrity verification: Tools &gt; Security checks the installed files against the official, ed25519-signed checksums on the CDN and reports any modified, missing or unexpected files.</item>
-            <item>Package export tool (Tools): builds a repo-layout zip of the component for packaging and pull requests.</item>
+            <item>Notification centre in the admin — a toolbar bell with a quick panel and a full history.</item>
+            <item>File-integrity check (Tools &gt; Security) that verifies your installed files against the official release.</item>
+            <item>One-click export of the component as an installable package.</item>
         </addition>
 
         <fix>
-            <item>Notifications: the sort dropdown showed raw language keys; the labels now translate correctly.</item>
-            <item>Notifications: the toolbar count badge now shows and hides correctly and is no longer overridden by the admin template styles.</item>
-            <item>Back-end menu: Tools is now the last item, after Notifications.</item>
+            <item>Notification sort options now show translated labels instead of raw keys.</item>
+            <item>The notification count badge now shows and hides correctly.</item>
+            <item>Tools now appears as the last item in the component menu.</item>
         </fix>
     </changelog>
 
@@ -34,37 +34,22 @@
         <version>1.0.4</version>
 
         <addition>
-            <item>Multilingual support across the catalog: per-language content (names, aliases and metadata) for categories, manufacturers, items and more.</item>
-            <item>Unique form fields: enforce unique values on custom form field options.</item>
-            <item>Items list (back end): new Categories and Manufacturers columns showing every related entry per item, with translated names.</item>
-            <item>Items list (back end): working Categories and Manufacturers filters (multi-select) in the search toolbar.</item>
-            <item>Order statuses: role-flag taxonomy (Initial / Cancellation / Completed) replacing the legacy is_default column, with save/publish/delete invariants.</item>
-            <item>Order statuses: status-change email notifications — per-status customer and admin emails, admin recipient picker, notify_customer toggle.</item>
-            <item>Order-status emails: selectable per-recipient email wrapper layout, position-based editors discovered from the chosen layout, token picker and live test-send.</item>
-            <item>Order-status emails: custom layouts are auto-discovered from the emails/order/ folder (component or admin-template override); their positions, labels and Restore-defaults content are driven by COM_ALFA_ORDEREMAIL_* language constants.</item>
-            <item>Update server configured so future releases are delivered via Joomla's extension updater.</item>
+            <item>Multilingual catalog — translate categories, manufacturers, items and more, each in its own language.</item>
+            <item>Unique values for custom form field options.</item>
+            <item>Categories and Manufacturers columns and filters on the Items list.</item>
+            <item>Order statuses with customisable status-change emails for customers and admins.</item>
+            <item>Customisable email layouts for order-status notifications.</item>
+            <item>Automatic updates delivered through Joomla's update manager.</item>
         </addition>
 
         <fix>
-            <item>Added the missing #__alfa_form_field_groups table to install, uninstall and the update schema — form field group screens no longer error on a clean install.</item>
-            <item>Update SQL moved to sql/updates/mysql/ (with the manifest schemapath) so the System &gt; Database "Fix" tool recognises com_alfa instead of silently skipping it.</item>
-            <item>Order-status email "Restore defaults" now fills every position (Subject, Header, Intro, Outro, Legal) instead of only the intro.</item>
-            <item>Items category filter form (filter_categories.xml): removed a broken PHP fragment embedded in an XML attribute.</item>
-            <item>Back-end Tools menu label (COM_ALFA_TITLE_TOOLS) now resolves in the Components menu (was missing from the system language file).</item>
-            <item>Cart menu item type: corrected the description language key and wording.</item>
-            <item>Manufacturer menu item type: replaced leftover COM_TEST_* skeleton language keys with COM_ALFA_* keys.</item>
-            <item>Order-status engine converted to InnoDB along with the remaining MyISAM tables for transaction and FK support.</item>
+            <item>Custom form field groups now work correctly on a fresh install.</item>
+            <item>The database Fix tool (System &gt; Database) now recognises the component.</item>
+            <item>Order-status email "Restore defaults" now fills every section, not just the intro.</item>
         </fix>
 
-        <language>
-            <item>Reorganised and de-duplicated the administrator language files; removed ~586 unused keys and grouped the rest into clearly labelled sections.</item>
-            <item>Cleaned the system language file: removed dead legacy-updater keys, added the Tools menu label, normalised menu-item-type titles and descriptions.</item>
-            <item>Replaced the borrowed com_content batch label with the component's own COM_ALFA_BATCH_OPTIONS, removing a cross-component dependency.</item>
-            <item>Extended the order-status email help note with guidance on creating custom layouts, positions and their language constants.</item>
-        </language>
-
         <note>
-            <item>Existing sites can apply the new #__alfa_form_field_groups table via System &gt; Database &gt; Fix; fresh installs get it automatically.</item>
+            <item>Existing sites can add the new form-field-groups table via System &gt; Database &gt; Fix; fresh installs get it automatically.</item>
         </note>
     </changelog>
 </changelogs>


### PR DESCRIPTION
README Joomla 5/6/7, plain-language changelog (1.0.4 folded into 1.0.5), notifications panel docblock tidy.