### PR TITLE
Media-zone UX + single image picker for Categories (1.0.7)

### DIFF
--- a/administrator/forms/category.xml
+++ b/administrator/forms/category.xml
@@ -164,9 +164,9 @@
                 name="medias"
                 type="MediaZone"
                 label="Insert Media: "
-                multiple="true"
+                multiple="false"
                 hiddenLabel="true"
-                types="media,url"
+                types="media"
         />
     </fieldset>
 </form>

--- a/administrator/languages/en-GB/com_alfa.ini
+++ b/administrator/languages/en-GB/com_alfa.ini
@@ -708,6 +708,7 @@ COM_ALFA_MEDIA_THUMBNAIL_ERROR = "Please select a valid thumbnail"
 COM_ALFA_MEDIA_THUMBNAIL_ERROR_ALERT = "One or more media items are missing a valid thumbnail. Please fix the items highlighted in red before saving."
 COM_ALFA_MEDIA_URL_LABEL = "Enter URL Address:"
 COM_ALFA_MEDIA_URL_THUMBNAIL = "Select URL thumbnail"
+COM_ALFA_MEDIA_URL_THUMBNAIL_HINT = "Optional: choose a thumbnail for this link, or a default image is used."
 COM_ALFA_SELECT_THUMBNAIL_MODAL_TITLE = "Select a thumbnail"
 
 ; ----- SEO -----

--- a/administrator/layouts/mediazone/dropmedias.php
+++ b/administrator/layouts/mediazone/dropmedias.php
@@ -56,6 +56,7 @@
 	$urlLabelText          = Text::_('COM_ALFA_MEDIA_URL_LABEL');
 	$insertUrlTitle        = Text::_('COM_ALFA_MEDIA_INSERT_URL');
 	$urlThumbnailText      = Text::_('COM_ALFA_MEDIA_URL_THUMBNAIL');
+	$urlThumbnailHintText  = Text::_('COM_ALFA_MEDIA_URL_THUMBNAIL_HINT');
 	$closeText             = Text::_('JCLOSE');
 	$addUrlText            = Text::_('COM_ALFA_MEDIA_ADD_URL');
 
@@ -109,7 +110,10 @@
             <label for="media-url-input" class="form-label">{$urlLabelText}</label>
             <input type="url" class="form-control" id="media-url-input" placeholder="https://example.com">
             <small id="media-url-error" class="hidden">-</small>
-            <button type="button" class="btn btn-primary media-url-thumbnail-btn">{$urlThumbnailText}</button>
+        </div>
+        <div class="media-url-thumb">
+            <small class="media-url-thumb-hint">{$urlThumbnailHintText}</small>
+            <button type="button" class="btn btn-outline-secondary btn-sm media-url-thumbnail-btn">{$urlThumbnailText}</button>
         </div>
         <div>
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{$closeText}</button>

--- a/changelog.xml
+++ b/changelog.xml
@@ -12,6 +12,11 @@
             <item>Clarified the wording of the file-integrity security note.</item>
             <item>Removed the unused Metadata fields from the Place editor (places are not public pages).</item>
         </fix>
+
+        <change>
+            <item>The media-zone URL-thumbnail picker now explains that a default image is used if none is chosen, with a tidier preview.</item>
+            <item>Categories now use a single image picker (no URL option), matching Manufacturers.</item>
+        </change>
     </changelog>
 
     <changelog>

--- a/media/css/admin/mediazone.css
+++ b/media/css/admin/mediazone.css
@@ -440,3 +440,22 @@
         grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
     }
 }
+/* ── URL thumbnail picker (media zone) ── */
+.media-url-thumb {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: .5rem;
+}
+.media-url-thumb-hint {
+    font-size: .8rem;
+    color: #6c757d;
+}
+.media-url-thumb-preview {
+    width: 96px;
+    height: 96px;
+    object-fit: cover;
+    border-radius: 12px;
+    border: 1px solid #e2e2e6;
+    background: #f7f7f8;
+}

--- a/media/js/admin/mediazone.js
+++ b/media/js/admin/mediazone.js
@@ -428,7 +428,7 @@
 
             // Thumbnail preview inside URL modal
             const thumbPreview = document.createElement('img');
-            thumbPreview.style.cssText = 'margin-top:10px;margin-left:3px;border-radius:15px;object-fit:cover;';
+            thumbPreview.className = 'media-url-thumb-preview';
 
             if (thumbBtn && pickerInput && pickerOpenBtn) {
                 thumbBtn.addEventListener('click', () => pickerOpenBtn.click());
@@ -436,9 +436,7 @@
                 pickerInput.addEventListener('change', () => {
                     const safePath = encodeURI(pickerInput.value);
 
-                    thumbPreview.width  = 100;
-                    thumbPreview.height = 100;
-                    thumbPreview.src    = '/' + safePath;
+                    thumbPreview.src = '/' + safePath;
                     thumbBtn.insertAdjacentElement('afterend', thumbPreview);
                 });
             }


### PR DESCRIPTION
Part of 1.0.7. Media zone: friendly hint that a default thumbnail is used if none chosen, lighter optional button, thumbnail preview moved from inline styles to a CSS class. Categories: single image picker (no URL), matching Manufacturers.