### PR TITLE
Claude PR review skill (project-specialist reviewer)

### DIFF
--- a/.github/review-guidelines.md
+++ b/.github/review-guidelines.md
@@ -1,0 +1,73 @@
+# Alfa Commerce — PR Review Skill
+
+Review PRs for **com_alfa** (Joomla 4/5/6 eCommerce component; PHP, no Composer deps) as a com_alfa
+**and** Joomla specialist. The rules below are this project's review rulebook — **extend it** by
+adding a directive under the right heading, or a new heading, as conventions evolve. Read `CLAUDE.md`
+for architecture.
+
+**How to review** — comment inline, concise, severity-tagged: 🔴 breaks installs/data/security ·
+🟡 likely bug or convention · 🔵 minor. Never flag style (PHP CS Fixer auto-commits fixes) or anything
+PHPStan reports. Only raise what you're confident about; acknowledge good work.
+
+## Release & migrations
+- Require a `<version>` bump in `alfa.xml` + a `changelog.xml` entry for any shipped-code change.
+  Reject re-touching an already-published version (changes the sha256, breaks signed integrity). 🔴
+- Require **all three** for a schema change: `sql/updates/mysql/<ver>.sql` (that delta only) + the same
+  folded into `sql/install.mysql.utf8.sql` + the version bump. Files removed → `files/removed/<ver>.json`. 🔴
+- Require **one column per `ALTER`** (Joomla's Database-Fix parser reads only the first), idempotent
+  deltas (`IF [NOT] EXISTS`), and `#__` + utf8mb4 + indexes on new tables; reject duplicate
+  `CREATE TABLE` in the install schema. 🔴
+
+## Database queries
+- Reject SQL built from request data: require `quoteName()` on identifiers, bound/`quote()` values,
+  whitelisted `ORDER BY` + direction, and `$db->escape($x, true)` for `LIKE`. 🔴
+- Flag a `getQuery(true)` reused without `clear()`, an unguarded null `loadResult()`, and
+  `insert/updateObject` properties that aren't real columns (+ missing key arg on update). 🟡
+- Flag N+1 queries in loops (→ `whereIn()`/JOIN), non-atomic multi-row writes (→ transaction), and
+  un-indexed new WHERE/JOIN/ORDER columns on big tables (`#__alfa_items|_orders|_media|_items_price_index`);
+  require the price index synced on item writes. 🟡
+
+## Joomla gotchas (the ones this app hits)
+- Reject a custom `AbstractEvent` `setX`/`onSetX` named like a **constructor arg** — Joomla calls it as
+  a mutator at construction and silently nulls the value; results use distinct keys. 🔴
+- Require a custom controller `__construct($config)` to forward the injected MVCFactory, else
+  `getModel()` returns false and list/save/checkin break. 🔴
+- `LayoutHelper::render()` in an AJAX/JSON task needs an **explicit base path** (else it silently
+  returns empty). 🟡
+- `onBeforeCompileHead` → guard `getDocument() instanceof HtmlDocument`. 🟡
+- Use only `icon-*` classes that exist in Joomla's icon set (`icon-unlink` doesn't); `Text::script()`
+  for any key read in JS; exact `joomla.asset.json` names; don't `defer` `$(document).ready` binders. 🟡
+
+## Multilingual fields
+- Reject a base-table column for a `multilingual_table` field — a NOT-NULL one makes every save fail
+  (*"doesn't have a default value"*). Values live in `#__alfa_<entity>_<langtag>`; saved via
+  `saveMultilingualData()`, read via `addMultilingualJoinToQuery()`. 🔴
+
+## Security
+- No injection (above); no secrets in the repo (the signing key is server-only). Require
+  `Session::checkToken()` on state-changing tasks and `authorise()` on privileged actions; reject
+  sensitive IDs passed in URLs (verify server-side). The integrity baseline is captured only in
+  `script.php` postflight and the "clean" verdict stays gated behind HMAC. 🔴
+
+## Conventions
+- Namespaces `Alfa\Component\Alfa\{Administrator|Site|Api}`; `{Name}Controller/Model`,
+  `{Name}\HtmlView`; events `{Context}{Action}Event` in `src/Event/`. Require **named arguments** on
+  calls (house style), professional PHPDoc on classes/methods, and Joomla built-ins only (no Composer);
+  new plugin → `services/provider.php`. 🟡
+- When a DB column or field read by a plugin changes/renames, require its consumers updated **in
+  lockstep**. Event/plugin handlers must stay **pure side effects** — never hijack a response (e.g.
+  the controller's JSON) that isn't theirs. 🟡
+
+## i18n
+- Every used `Text::` key must be defined; `.ini` = one `KEY="…"` per line, no newline inside a value,
+  `&quot;` for embedded quotes. 🔵
+
+## Don't flag
+Style/formatting (CS Fixer), PHPStan findings, or dev-box integrity "drift" (normal for unreleased
+files). Premium gateways/modules (Revolut, Viva, BoxNow, Klarna, PayPal, filters, media optimizer) are
+**CDN-only by design** — never suggest bundling them or mention their removal publicly. PRs target
+`developer`, never `main`.
+
+---
+*Extend this skill by adding a directive under the relevant heading (or a new heading) — keep each one
+a single, checkable command.*

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -17,14 +17,36 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Run Claude Code Review
+      - name: Run Claude PR Review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"
+
+          # The Alfa Commerce specialist review skill.
+          prompt: |
+            You are the Alfa Commerce specialist reviewer for this pull request.
+            First read `.github/review-guidelines.md` (the project review rulebook) and `CLAUDE.md`,
+            then review ONLY the changes in this PR against those rules.
+
+            Post concise, INLINE, severity-tagged findings (🔴 / 🟡 / 🔵). Prioritise correctness,
+            security, Joomla-API misuse, data integrity, and release/migration completeness.
+            Do NOT flag style/formatting (PHP CS Fixer handles it) or PHPStan-level issues.
+            Acknowledge genuinely good work. If the PR is clean, say so briefly — don't invent issues.
+
+          # Read-only review: analyse + comment, never modify code.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+          # Inline comments on the exact lines, with "Fix this" links.
+          use_sticky_comment: false
+          classify_inline_comments: true
+          include_fix_links: true


### PR DESCRIPTION
Adds .github/review-guidelines.md — a com_alfa + Joomla review rulebook (release/migration discipline, DB-query correctness, Joomla gotchas, multilingual, security; extendable, command-style) — and wires the Claude review workflow to use it (focused prompt, read-only tools, inline severity-tagged comments).