### PR TITLE
CI: fix PHPStan framework errors + Node-20 action deprecation

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -20,7 +20,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
         run: php-cs-fixer fix --config=.php-cs-fixer.php --allow-risky=yes --diff
 
       - name: Commit fixes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_message: "style: auto-fix code style with PHP CS Fixer"
           commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,8 +14,12 @@ parameters:
         - */language/*
 
     ignoreErrors:
-        # Joomla framework classes are not available in CI (no stubs package exists)
+        # Joomla framework classes are not available in CI (no Composer/stubs package).
+        # Suppress every framework-visibility error so PHPStan focuses on our own logic:
         - identifier: class.notFound
+        - '#extends unknown class Joomla\\#'              # controllers/views extend Joomla\CMS base classes
+        - '#implements unknown interface Joomla\\#'
+        - '#but .+ does not extend any class#'            # parent::x() where the (unknown) parent is a Joomla class
         # Joomla dynamic properties and magic methods
         - '#Access to an undefined property#'
         - '#Call to an undefined method.*\\\\HtmlView::#'


### PR DESCRIPTION
PHPStan: suppress the remaining Joomla framework-visibility errors (extends/implements unknown class, no-parent) — consistent with the existing class.notFound ignore, since the repo is Composer-free. Bumps actions/checkout to v5 and git-auto-commit-action to v6 (Node 24).