### PR TITLE
CI: Claude reviewer via OAuth token

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Claude PR Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
 
           # The Alfa Commerce specialist review skill.


### PR DESCRIPTION
Switches the Claude PR reviewer from a pay-per-token API key to a Claude Max OAuth token (CLAUDE_CODE_OAUTH_TOKEN secret).