### PR TITLE
[test] Claude reviewer smoke test

### DIFF
--- a/REVIEWER_SMOKE_TEST.md
+++ b/REVIEWER_SMOKE_TEST.md
@@ -1,0 +1,3 @@
+# Reviewer smoke test
+
+Throwaway PR to confirm the Claude PR reviewer runs with the new OAuth token. Will be closed unmerged.


### PR DESCRIPTION
Throwaway PR to confirm the Claude reviewer runs with the new OAuth token. Closing unmerged.