### PR TITLE
Sync developer → main: PHPStan vs latest Joomla + review-skill rules

### DIFF
--- a/.github/phpstan-bootstrap.php
+++ b/.github/phpstan-bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+// Constants Joomla defines at runtime (not discoverable by scanning the source),
+// declared so the component code analyses cleanly under PHPStan.
+defined('_JEXEC') or define('_JEXEC', 1);
+defined('DS') or define('DS', DIRECTORY_SEPARATOR);
+defined('JPATH_ROOT') or define('JPATH_ROOT', __DIR__);
+defined('JPATH_BASE') or define('JPATH_BASE', JPATH_ROOT);
+defined('JPATH_SITE') or define('JPATH_SITE', JPATH_ROOT);
+defined('JPATH_ADMINISTRATOR') or define('JPATH_ADMINISTRATOR', JPATH_ROOT . '/administrator');
+defined('JPATH_API') or define('JPATH_API', JPATH_ROOT . '/api');
+defined('JPATH_LIBRARIES') or define('JPATH_LIBRARIES', JPATH_ROOT . '/libraries');
+defined('JPATH_PLUGINS') or define('JPATH_PLUGINS', JPATH_ROOT . '/plugins');
+defined('JPATH_THEMES') or define('JPATH_THEMES', JPATH_ROOT . '/templates');
+defined('JPATH_CACHE') or define('JPATH_CACHE', JPATH_ROOT . '/cache');
+defined('JPATH_CONFIGURATION') or define('JPATH_CONFIGURATION', JPATH_ROOT);
+defined('JPATH_MANIFESTS') or define('JPATH_MANIFESTS', JPATH_ROOT . '/administrator/manifests');
+defined('JDEBUG') or define('JDEBUG', 0);

--- a/.github/phpstan-bootstrap.php
+++ b/.github/phpstan-bootstrap.php
@@ -4,7 +4,7 @@
 // declared so the component code analyses cleanly under PHPStan.
 defined('_JEXEC') or define('_JEXEC', 1);
 defined('DS') or define('DS', DIRECTORY_SEPARATOR);
-defined('JPATH_ROOT') or define('JPATH_ROOT', __DIR__);
+defined('JPATH_ROOT') or define('JPATH_ROOT', dirname(__DIR__));
 defined('JPATH_BASE') or define('JPATH_BASE', JPATH_ROOT);
 defined('JPATH_SITE') or define('JPATH_SITE', JPATH_ROOT);
 defined('JPATH_ADMINISTRATOR') or define('JPATH_ADMINISTRATOR', JPATH_ROOT . '/administrator');

--- a/.github/review-guidelines.md
+++ b/.github/review-guidelines.md
@@ -56,6 +56,9 @@ PHPStan reports. Only raise what you're confident about; acknowledge good work.
 - When a DB column or field read by a plugin changes/renames, require its consumers updated **in
   lockstep**. Event/plugin handlers must stay **pure side effects** — never hijack a response (e.g.
   the controller's JSON) that isn't theirs. 🟡
+- `tmpl/` and `layouts/` are presentation-only **and excluded from PHPStan** (a blind spot). Flag
+  heavy logic there — DB queries, pricing/business calculations, complex branching — it belongs in a
+  model/helper/controller; the template should only loop, escape and format. 🟡
 
 ## i18n
 - Every used `Text::` key must be defined; `.ini` = one `KEY="…"` per line, no newline inside a value,

--- a/.github/review-guidelines.md
+++ b/.github/review-guidelines.md
@@ -61,6 +61,9 @@ PHPStan reports. Only raise what you're confident about; acknowledge good work.
   model/helper/controller; the template should only loop, escape and format. 🟡
 
 ## i18n
+- Flag hardcoded **user-facing** strings (labels, buttons, headings, `enqueueMessage`, user-shown
+  exception/error text) in PHP and `tmpl` — they must be `Text::_()` / `Text::sprintf()` keys defined in
+  the `.ini`, never literals. Log lines, array/option keys, HTML/CSS attributes and class names are exempt. 🟡
 - Every used `Text::` key must be defined; `.ini` = one `KEY="…"` per line, no newline inside a value,
   `&quot;` for embedded quotes. 🔵
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Fetch latest Joomla (PHPStan symbol resolution)
         run: |
-          url=$(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | jq -r '.assets[] | select(.name | endswith("Full_Package.zip")) | .browser_download_url' | head -1)
+          url=$(curl -sL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/joomla/joomla-cms/releases/latest | jq -r '.assets[] | select(.name | endswith("Full_Package.zip")) | .browser_download_url' | head -1)
           echo "Latest Joomla package: $url"
           curl -sL -o /tmp/joomla.zip "$url"
           mkdir -p joomla && unzip -q /tmp/joomla.zip -d joomla

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -52,6 +52,13 @@ jobs:
           php-version: "8.2"
           tools: phpstan
 
+      - name: Fetch latest Joomla (PHPStan symbol resolution)
+        run: |
+          url=$(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | jq -r '.assets[] | select(.name | endswith("Full_Package.zip")) | .browser_download_url' | head -1)
+          echo "Latest Joomla package: $url"
+          curl -sL -o /tmp/joomla.zip "$url"
+          mkdir -p joomla && unzip -q /tmp/joomla.zip -d joomla
+
       - name: Run PHPStan
-        run: phpstan analyse --configuration=phpstan.neon --memory-limit=512M --error-format=github
+        run: phpstan analyse --configuration=phpstan.neon --memory-limit=1G --error-format=github
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -735,3 +735,4 @@ Desktop.ini
 /README.txt
 /robots.txt.dist
 /web.config.txt
+/joomla/

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,1243 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Method Joomla\\CMS\\Application\\CMSApplicationInterface\:\:getMessageQueue\(\) invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: administrator/src/Controller/OrderController.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Controller\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Controller/OrdersController.php
+
+		-
+			message: '#^Property Joomla\\CMS\\User\\User\:\:\$email \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: administrator/src/Controller/OrderstatusController.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Controller\\PluginController\:\:trigger\(\) should return bool\|Joomla\\CMS\\MVC\\Controller\\BaseController but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: administrator/src/Controller/PluginController.php
+
+		-
+			message: '#^Variable \$response might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: administrator/src/Controller/PluginController.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Controller\\SeoController\:\:calculateScore\(\) should return int but returns float\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Controller/SeoController.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between non\-empty\-string and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: administrator/src/Controller/SeoController.php
+
+		-
+			message: '#^Variable \$app might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: administrator/src/Controller/SeoController.php
+
+		-
+			message: '#^PHPDoc tag @var above a method has no effect\.$#'
+			identifier: varTag.misplaced
+			count: 1
+			path: administrator/src/Event/Fields/FieldsEvent.php
+
+		-
+			message: '#^PHPDoc tag @var above a method has no effect\.$#'
+			identifier: varTag.misplaced
+			count: 1
+			path: administrator/src/Event/Fields/PrepareDomEvent.php
+
+		-
+			message: '#^PHPDoc tag @return with type mixed is not subtype of native type static\(Joomla\\CMS\\Event\\CustomFields\\AfterPrepareFieldEvent\)\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: administrator/src/Event/Fields/_AfterPrepareFieldEvent.php
+
+		-
+			message: '#^PHPDoc tag @var above a method has no effect\.$#'
+			identifier: varTag.misplaced
+			count: 1
+			path: administrator/src/Event/General/LayoutEvent.php
+
+		-
+			message: '#^Call to an undefined method Alfa\\Component\\Alfa\\Administrator\\Event\\Shipments\\AdminOrderAfterSaveEvent\:\:getSubject\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: administrator/src/Event/Shipments/AdminOrderAfterSaveEvent.php
+
+		-
+			message: '#^Call to an undefined method Alfa\\Component\\Alfa\\Administrator\\Event\\Shipments\\AdminOrderBeforeSaveEvent\:\:getSubject\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: administrator/src/Event/Shipments/AdminOrderBeforeSaveEvent.php
+
+		-
+			message: '#^Call to an undefined method Alfa\\Component\\Alfa\\Administrator\\Event\\Shipments\\AdminOrderDeleteEvent\:\:getSubject\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: administrator/src/Event/Shipments/AdminOrderDeleteEvent.php
+
+		-
+			message: '#^Call to an undefined method Alfa\\Component\\Alfa\\Administrator\\Event\\Shipments\\CalculateShippingCostEvent\:\:getSubject\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: administrator/src/Event/Shipments/CalculateShippingCostEvent.php
+
+		-
+			message: '#^Call to an undefined method Alfa\\Component\\Alfa\\Administrator\\Event\\Shipments\\OrderAfterPlaceEvent\:\:getSubject\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: administrator/src/Event/Shipments/OrderAfterPlaceEvent.php
+
+		-
+			message: '#^Call to an undefined method Alfa\\Component\\Alfa\\Administrator\\Event\\Shipments\\OrderPlaceEvent\:\:getSubject\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: administrator/src/Event/Shipments/OrderPlaceEvent.php
+
+		-
+			message: '#^Parameter \#4 \$height of method Joomla\\CMS\\Editor\\Editor\:\:display\(\) expects string, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: administrator/src/Field/EmailPositionsField.php
+
+		-
+			message: '#^Property Joomla\\CMS\\Form\\Field\\EditorField\:\:\$height \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: administrator/src/Field/MultilingualEditorField.php
+
+		-
+			message: '#^Property Joomla\\CMS\\Form\\Field\\EditorField\:\:\$width \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: administrator/src/Field/MultilingualEditorField.php
+
+		-
+			message: '#^Right side of && is always false\.$#'
+			identifier: booleanAnd.rightAlwaysFalse
+			count: 1
+			path: administrator/src/Helper/ActionRegistry.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Helper\\AlfaHelper\:\:setAssocsToDb\(\) with return type void returns false but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: administrator/src/Helper/AlfaHelper.php
+
+		-
+			message: '#^Variable \$currentPath might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: administrator/src/Helper/AlfaHelper.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: administrator/src/Helper/FieldsHelper.php
+
+		-
+			message: '#^Comparison operation "\<" between int\<1, max\> and 1 is always false\.$#'
+			identifier: smaller.alwaysFalse
+			count: 2
+			path: administrator/src/Helper/MediaHelper.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Helper\\MediaHelper\:\:getMediaData\(\) should return array\<object\> but returns array\<list\>\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Helper/MediaHelper.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Helper\\MediaHelper\:\:getPlaceholderMedia\(\) never returns null so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: administrator/src/Helper/MediaHelper.php
+
+		-
+			message: '#^Result of \|\| is always false\.$#'
+			identifier: booleanOr.alwaysFalse
+			count: 1
+			path: administrator/src/Helper/MediaHelper.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between int\<1, max\> and 0 will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: administrator/src/Helper/MediaHelper.php
+
+		-
+			message: '#^Variable \$finalThumbnail might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: administrator/src/Helper/MediaHelper.php
+
+		-
+			message: '#^Cannot call method getItems\(\) on object\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: administrator/src/Helper/NotificationHelper.php
+
+		-
+			message: '#^Cannot call method getState\(\) on object\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: administrator/src/Helper/NotificationHelper.php
+
+		-
+			message: '#^Cannot call method setState\(\) on object\|false\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: administrator/src/Helper/NotificationHelper.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Helper\\OrderEmailHelper\:\:discoverSequence\(\) should return array\<int, array\{type\: string, name\?\: string\}\> but returns array\<string\>\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Helper/OrderEmailHelper.php
+
+		-
+			message: '#^Parameter \#3 \$basePath of static method Joomla\\CMS\\Layout\\LayoutHelper\:\:render\(\) expects string, null given\.$#'
+			identifier: argument.type
+			count: 3
+			path: administrator/src/Helper/OrderEmailHelper.php
+
+		-
+			message: '#^Argument of an invalid type stdClass supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: administrator/src/Helper/OrderHelper.php
+
+		-
+			message: '#^PHPDoc tag @return with type array is incompatible with native type Alfa\\Component\\Alfa\\Site\\Service\\Pricing\\PriceContext\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: administrator/src/Helper/OrderHelper.php
+
+		-
+			message: '#^Comparison operation "\>" between int\<1, max\> and 0 is always true\.$#'
+			identifier: greater.alwaysTrue
+			count: 1
+			path: administrator/src/Helper/OrderPaymentHelper.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 2
+			path: administrator/src/Helper/OrderPaymentHelper.php
+
+		-
+			message: '#^Comparison operation "\>" between int\<1, max\> and 0 is always true\.$#'
+			identifier: greater.alwaysTrue
+			count: 1
+			path: administrator/src/Helper/OrderShipmentHelper.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 2
+			path: administrator/src/Helper/OrderShipmentHelper.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments string, array\{\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: administrator/src/Helper/PackageHelper.php
+
+		-
+			message: '#^Right side of && is always false\.$#'
+			identifier: booleanAnd.rightAlwaysFalse
+			count: 1
+			path: administrator/src/Helper/PluginLayoutHelper.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/CategoriesModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CategoryModel\:\:getForm\(\) has invalid return type JForm\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/CategoryModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CategoryModel\:\:getForm\(\) should return bool\|JForm but returns Joomla\\CMS\\Form\\Form\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/CategoryModel.php
+
+		-
+			message: '#^Offset ''\#__alfa_categories'' on array\{''\#__alfa_categories''\: array\{''parent_id''\}\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: administrator/src/Model/CategoryModel.php
+
+		-
+			message: '#^Property Alfa\\Component\\Alfa\\Administrator\\Model\\CategoryModel\:\:\$item \(null\) does not accept array\<int, bool\|stdClass\>\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: administrator/src/Model/CategoryModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CouponModel\:\:getForm\(\) has invalid return type JForm\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/CouponModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CouponModel\:\:getForm\(\) should return bool\|JForm but returns Joomla\\CMS\\Form\\Form\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/CouponModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/CouponModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CouponsModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/CouponsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CouponsModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/CouponsModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/CouponsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CurrenciesModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/CurrenciesModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CurrenciesModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/CurrenciesModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/CurrenciesModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CurrencyModel\:\:getForm\(\) has invalid return type JForm\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/CurrencyModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CurrencyModel\:\:getForm\(\) should return bool\|JForm but returns Joomla\\CMS\\Form\\Form\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/CurrencyModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CurrencyModel\:\:prepareTable\(\) with return type void returns null but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: administrator/src/Model/CurrencyModel.php
+
+		-
+			message: '#^Result of method Joomla\\CMS\\MVC\\Model\\AdminModel\:\:prepareTable\(\) \(void\) is used\.$#'
+			identifier: staticMethod.void
+			count: 1
+			path: administrator/src/Model/CurrencyModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CustomModel\:\:getForm\(\) has invalid return type JForm\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/CustomModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CustomModel\:\:getForm\(\) should return bool\|JForm but returns Joomla\\CMS\\Form\\Form\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/CustomModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CustomsModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/CustomsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\CustomsModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/CustomsModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/CustomsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\DiscountModel\:\:getForm\(\) has invalid return type JForm\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/DiscountModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\DiscountModel\:\:getForm\(\) should return bool\|JForm but returns Joomla\\CMS\\Form\\Form\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/DiscountModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\DiscountModel\:\:prepareTable\(\) with return type void returns null but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: administrator/src/Model/DiscountModel.php
+
+		-
+			message: '#^Result of method Joomla\\CMS\\MVC\\Model\\AdminModel\:\:prepareTable\(\) \(void\) is used\.$#'
+			identifier: staticMethod.void
+			count: 1
+			path: administrator/src/Model/DiscountModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\DiscountsModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/DiscountsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\DiscountsModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/DiscountsModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/DiscountsModel.php
+
+		-
+			message: '#^Cannot access property \$fieldsparams on bool\|object\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: administrator/src/Model/FormfieldModel.php
+
+		-
+			message: '#^Cannot access property \$params on bool\|object\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: administrator/src/Model/FormfieldModel.php
+
+		-
+			message: '#^Cannot access property \$showon on bool\|object\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: administrator/src/Model/FormfieldModel.php
+
+		-
+			message: '#^Expression on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.expr
+			count: 1
+			path: administrator/src/Model/FormfieldModel.php
+
+		-
+			message: '#^PHPDoc tag @return with type mixed is not subtype of native type string\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: administrator/src/Model/FormfieldModel.php
+
+		-
+			message: '#^Property Alfa\\Component\\Alfa\\Administrator\\Model\\FormfieldModel\:\:\$batch_copymove \(string\) does not accept default value of type false\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: administrator/src/Model/FormfieldModel.php
+
+		-
+			message: '#^Property Alfa\\Component\\Alfa\\Administrator\\Model\\FormfieldModel\:\:\$item \(null\) does not accept bool\|object\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: administrator/src/Model/FormfieldModel.php
+
+		-
+			message: '#^Return type \(void\) of method Alfa\\Component\\Alfa\\Administrator\\Model\\FormfieldModel\:\:delete\(\) should be compatible with return type \(bool\) of method Joomla\\CMS\\MVC\\Model\\AdminModel\:\:delete\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: administrator/src/Model/FormfieldModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\FormFieldsModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/FormfieldsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\FormFieldsModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/FormfieldsModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/FormfieldsModel.php
+
+		-
+			message: '#^Call to an undefined static method Alfa\\Component\\Alfa\\Administrator\\Helper\\AlfaHelper\:\:setAllowedUserGroups\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: administrator/src/Model/ItemModel.php
+
+		-
+			message: '#^Call to an undefined static method Alfa\\Component\\Alfa\\Administrator\\Helper\\AlfaHelper\:\:setAllowedUsers\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: administrator/src/Model/ItemModel.php
+
+		-
+			message: '#^Parameter \#1 \$text of method Joomla\\Database\\DatabaseInterface\:\:quote\(\) expects array\|string, int\<1, max\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: administrator/src/Model/ItemModel.php
+
+		-
+			message: '#^Property Alfa\\Component\\Alfa\\Administrator\\Model\\ItemModel\:\:\$batch_copymove \(string\) does not accept default value of type false\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: administrator/src/Model/ItemModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\ManufacturerModel\:\:getForm\(\) has invalid return type JForm\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/ManufacturerModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\ManufacturerModel\:\:getForm\(\) should return bool\|JForm but returns Joomla\\CMS\\Form\\Form\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/ManufacturerModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\ManufacturerModel\:\:prepareTable\(\) with return type void returns null but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: administrator/src/Model/ManufacturerModel.php
+
+		-
+			message: '#^Result of method Joomla\\CMS\\MVC\\Model\\AdminModel\:\:prepareTable\(\) \(void\) is used\.$#'
+			identifier: staticMethod.void
+			count: 1
+			path: administrator/src/Model/ManufacturerModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\ManufacturersModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/ManufacturersModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\ManufacturersModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/ManufacturersModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/ManufacturersModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\OrderModel\:\:getItem\(\) should return stdClass\|false but returns null\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/OrderModel.php
+
+		-
+			message: '#^Parameter \#1 \$text of method Joomla\\Database\\DatabaseInterface\:\:quote\(\) expects array\|string, int given\.$#'
+			identifier: argument.type
+			count: 2
+			path: administrator/src/Model/OrderModel.php
+
+		-
+			message: '#^Variable \$oldItemSnapshot might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: administrator/src/Model/OrderModel.php
+
+		-
+			message: '#^Variable \$orders might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: administrator/src/Model/OrderModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\OrdersModel\:\:getListQuery\(\) should return Joomla\\Database\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/OrdersModel.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between mixed and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: administrator/src/Model/OrderstatusModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\PaymentModel\:\:getForm\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\Form\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/PaymentModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\PaymentModel\:\:getForm\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\Form\|bool but returns Joomla\\CMS\\Form\\Form\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/PaymentModel.php
+
+		-
+			message: '#^Property Alfa\\Component\\Alfa\\Administrator\\Model\\PaymentModel\:\:\$item \(null\) does not accept stdClass\|false\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: administrator/src/Model/PaymentModel.php
+
+		-
+			message: '#^Property Alfa\\Component\\Alfa\\Administrator\\Model\\PaymentModel\:\:\$item \(null\) on left side of \?\? is always null\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: administrator/src/Model/PaymentModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\PaymentsModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/PaymentsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\PaymentsModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/PaymentsModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/PaymentsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\PlaceModel\:\:getForm\(\) has invalid return type JForm\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/PlaceModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\PlaceModel\:\:getForm\(\) should return bool\|JForm but returns Joomla\\CMS\\Form\\Form\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/PlaceModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\PlacesModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/PlacesModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\PlacesModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/PlacesModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/PlacesModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\ShipmentModel\:\:getForm\(\) has invalid return type JForm\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/ShipmentModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\ShipmentModel\:\:getForm\(\) should return bool\|JForm but returns Joomla\\CMS\\Form\\Form\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/ShipmentModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\ShipmentsModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/ShipmentsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\ShipmentsModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/ShipmentsModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/ShipmentsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\TaxModel\:\:getForm\(\) has invalid return type JForm\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/TaxModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\TaxModel\:\:getForm\(\) should return bool\|JForm but returns Joomla\\CMS\\Form\\Form\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/TaxModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\TaxesModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Model/TaxesModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\TaxesModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Administrator\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/TaxesModel.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\Model\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/Model/TaxesModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\ToolsmediaModel\:\:getListQuery\(\) should return Joomla\\Database\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/ToolsmediaModel.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments string, array\{\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: administrator/src/Model/UsergroupModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Administrator\\Model\\UsersModel\:\:getListQuery\(\) should return Joomla\\Database\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: administrator/src/Model/UsersModel.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/CategoryTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\CategoryTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/CategoryTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/CouponTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\CouponTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/CouponTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/CurrencyTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\CurrencyTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/CurrencyTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/CustomTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\CustomTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/CustomTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/DiscountTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\DiscountTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/DiscountTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/FormfieldTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\FormfieldTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/FormfieldTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/ItemTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\ItemTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/ItemTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/ManufacturerTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\ManufacturerTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/ManufacturerTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\Database is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/OrderTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\OrderTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\Database\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/OrderTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/OrderstatusTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\OrderstatusTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/OrderstatusTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/PaymentTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\PaymentTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/PaymentTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/PlaceTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\PlaceTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/PlaceTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/ShipmentTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\ShipmentTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/ShipmentTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/TaxTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\TaxTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/TaxTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/UserTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\UserTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/UserTable.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$db with type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase is not subtype of native type Joomla\\Database\\DatabaseDriver\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: administrator/src/Table/UsergroupTable.php
+
+		-
+			message: '#^Parameter \$db of method Alfa\\Component\\Alfa\\Administrator\\Table\\UsergroupTable\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Administrator\\Table\\JDatabase\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/src/Table/UsergroupTable.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Administrator\\View\\Coupon\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: administrator/src/View/Coupon/HtmlView.php
+
+		-
+			message: '#^Offset ''checkedAt'' does not exist on array\{status\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: administrator/src/View/Tools/_integrity.php
+
+		-
+			message: '#^Offset ''injected'' does not exist on array\{status\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: administrator/src/View/Tools/_integrity.php
+
+		-
+			message: '#^Offset ''missing'' does not exist on array\{status\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: administrator/src/View/Tools/_integrity.php
+
+		-
+			message: '#^Offset ''modified'' does not exist on array\{status\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: administrator/src/View/Tools/_integrity.php
+
+		-
+			message: '#^Caught class libphonenumber\\NumberParseException not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: plugins/alfa-fields/tel/src/Rule/AlfatelRule.php
+
+		-
+			message: '#^Property Joomla\\CMS\\Menu\\MenuItem\:\:\$link \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: plugins/system/alfasync/src/Extension/Alfasync.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between mixed and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: plugins/system/alfasync/src/Extension/Alfasync.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: site/src/Controller/CartController.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Site\\Controller\\CartController\:\:recalculate\(\) should return Joomla\\CMS\\MVC\\Controller\\BaseController but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: site/src/Controller/CartController.php
+
+		-
+			message: '#^Parameter \#1 \$displayData of method Joomla\\CMS\\Layout\\FileLayout\:\:render\(\) expects array, Alfa\\Component\\Alfa\\Site\\Helper\\CartHelper given\.$#'
+			identifier: argument.type
+			count: 3
+			path: site/src/Controller/CartController.php
+
+		-
+			message: '#^Ternary operator condition is always false\.$#'
+			identifier: ternary.alwaysFalse
+			count: 1
+			path: site/src/Controller/CartController.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: site/src/Controller/CartController.php
+
+		-
+			message: '#^Variable \$result might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: site/src/Controller/CartController.php
+
+		-
+			message: '#^Cannot call method checkin\(\) on bool\|Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: site/src/Controller/CategoryController.php
+
+		-
+			message: '#^Cannot call method checkout\(\) on bool\|Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: site/src/Controller/CategoryController.php
+
+		-
+			message: '#^Cannot call method delete\(\) on bool\|Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: site/src/Controller/CategoryController.php
+
+		-
+			message: '#^Cannot call method getItem\(\) on bool\|Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: site/src/Controller/CategoryController.php
+
+		-
+			message: '#^Cannot call method publish\(\) on bool\|Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: site/src/Controller/CategoryController.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Site\\Controller\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 3
+			path: site/src/Controller/CategoryController.php
+
+		-
+			message: '#^Parameter \#1 \$message of class Exception constructor expects string, int given\.$#'
+			identifier: argument.type
+			count: 2
+			path: site/src/Controller/CategoryController.php
+
+		-
+			message: '#^Parameter \#2 \$urlparams \(bool\) of method Alfa\\Component\\Alfa\\Site\\Controller\\DisplayController\:\:display\(\) should be compatible with parameter \$urlparams \(array\) of method Joomla\\CMS\\MVC\\Controller\\BaseController\:\:display\(\)$#'
+			identifier: method.childParameterType
+			count: 1
+			path: site/src/Controller/DisplayController.php
+
+		-
+			message: '#^Parameter \#2 \$urlparams of method Joomla\\CMS\\MVC\\Controller\\BaseController\:\:display\(\) expects array, bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: site/src/Controller/DisplayController.php
+
+		-
+			message: '#^Parameter \#3 \$app of method Joomla\\CMS\\MVC\\Controller\\BaseController\:\:__construct\(\) expects Joomla\\CMS\\Application\\CMSApplicationInterface\|null, Alfa\\Component\\Alfa\\Site\\Controller\\CMSApplication\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: site/src/Controller/DisplayController.php
+
+		-
+			message: '#^Parameter \#4 \$input of method Joomla\\CMS\\MVC\\Controller\\BaseController\:\:__construct\(\) expects Joomla\\Input\\Input\|null, Alfa\\Component\\Alfa\\Site\\Controller\\Input\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: site/src/Controller/DisplayController.php
+
+		-
+			message: '#^Parameter \$app of method Alfa\\Component\\Alfa\\Site\\Controller\\DisplayController\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Site\\Controller\\CMSApplication\.$#'
+			identifier: class.notFound
+			count: 1
+			path: site/src/Controller/DisplayController.php
+
+		-
+			message: '#^Parameter \$input of method Alfa\\Component\\Alfa\\Site\\Controller\\DisplayController\:\:__construct\(\) has invalid type Alfa\\Component\\Alfa\\Site\\Controller\\Input\.$#'
+			identifier: class.notFound
+			count: 1
+			path: site/src/Controller/DisplayController.php
+
+		-
+			message: '#^Cannot call method checkin\(\) on bool\|Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: site/src/Controller/ManufacturerController.php
+
+		-
+			message: '#^Cannot call method checkout\(\) on bool\|Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: site/src/Controller/ManufacturerController.php
+
+		-
+			message: '#^Cannot call method delete\(\) on bool\|Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: site/src/Controller/ManufacturerController.php
+
+		-
+			message: '#^Cannot call method getItem\(\) on bool\|Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: site/src/Controller/ManufacturerController.php
+
+		-
+			message: '#^Cannot call method publish\(\) on bool\|Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: site/src/Controller/ManufacturerController.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Alfa\\Component\\Alfa\\Site\\Controller\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 3
+			path: site/src/Controller/ManufacturerController.php
+
+		-
+			message: '#^Parameter \#1 \$message of class Exception constructor expects string, int given\.$#'
+			identifier: argument.type
+			count: 2
+			path: site/src/Controller/ManufacturerController.php
+
+		-
+			message: '#^Variable \$html on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.variable
+			count: 1
+			path: site/src/Helper/AlfaHelper.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between mixed and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: site/src/Helper/OrderPlaceHelper.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: site/src/Helper/PluginLayoutHelper.php
+
+		-
+			message: '#^Parameter \#1 \$ids of method Alfa\\Component\\Alfa\\Site\\Model\\ItemsModel\:\:getRecordsByIds\(\) expects array\<int\>, array\<string\> given\.$#'
+			identifier: argument.type
+			count: 2
+			path: site/src/Model/ItemsModel.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between float\|int\|numeric\-string and '''' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: site/src/Model/ItemsModel.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between float\|int\|numeric\-string and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: site/src/Model/ItemsModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Site\\Model\\ManufacturersModel\:\:getListQuery\(\) has invalid return type Alfa\\Component\\Alfa\\Site\\Model\\DatabaseQuery\.$#'
+			identifier: class.notFound
+			count: 1
+			path: site/src/Model/ManufacturersModel.php
+
+		-
+			message: '#^Method Alfa\\Component\\Alfa\\Site\\Model\\ManufacturersModel\:\:getListQuery\(\) should return Alfa\\Component\\Alfa\\Site\\Model\\DatabaseQuery but returns Joomla\\Database\\QueryInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: site/src/Model/ManufacturersModel.php
+
+		-
+			message: '#^Property Alfa\\Component\\Alfa\\Site\\Model\\UrlListModel\:\:\$app \(Joomla\\CMS\\Application\\CMSApplication\) does not accept Joomla\\CMS\\Application\\CMSApplicationInterface\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: site/src/Model/UrlListModel.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between mixed and array\{\} will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: site/src/Model/UrlListModel.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between int and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: site/src/Service/Pricing/Money.php
+
+		-
+			message: '#^Static property Alfa\\Component\\Alfa\\Site\\Service\\Router\:\:\$categoryPathCache is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: site/src/Service/Router.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between mixed and 0 will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: site/src/Service/Router.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between mixed~\(0\|0\.0\|''''\|''0''\|array\{\}\|false\|null\) and ''0'' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: site/src/Service/Router.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,9 @@
+includes:
+    # Pre-existing genuine findings (legacy J-prefixed docblock types, etc.),
+    # snapshotted so CI is green and only NEW regressions are flagged. Chip away
+    # and regenerate with: scripts/phpstan-fetch-joomla.sh && phpstan analyse --generate-baseline
+    - phpstan-baseline.neon
+
 parameters:
     level: 5
     paths:
@@ -7,9 +13,10 @@ parameters:
         - plugins
         - modules
 
-    # The latest Joomla is downloaded into ./joomla in CI so PHPStan can resolve the
-    # Joomla\CMS\* / Joomla\* framework classes our code extends (the repo has no
-    # Composer dependencies). See .github/workflows/code-quality.yml.
+    # Joomla is downloaded into ./joomla so PHPStan can resolve the Joomla\CMS\* /
+    # Joomla\* framework classes our code extends (the repo has no Composer deps).
+    # CI fetches it automatically (see .github/workflows/code-quality.yml); for a
+    # local run, populate ./joomla first with scripts/phpstan-fetch-joomla.sh.
     scanDirectories:
         - joomla
 
@@ -17,16 +24,33 @@ parameters:
         - .github/phpstan-bootstrap.php
 
     excludePaths:
-        - */tmpl/*
-        - */layouts/*
-        - */language/*
+        - */tmpl/*        # view templates: procedural HTML scripts ($this-bound, extracted vars) — presentation, not logic
+        - */layouts/*     # JLayout files: same, render $displayData procedurally
+        - */*BACKUP*      # stray developer backup files are dead code, not maintained source
 
     ignoreErrors:
-        # Joomla models/views expose values via magic __get / dynamic methods,
-        # which PHPStan can't infer even with the framework scanned.
+        # Joomla magic access: models/views expose values via __get / dynamic
+        # methods PHPStan can't infer even with the framework scanned.
         - '#Access to an undefined property#'
-        - '#Call to an undefined method.*\\\\HtmlView::#'
-        - '#Call to an undefined method.*\\\\BaseController::#'
+
+        # Joomla interface→concrete typing: these methods exist on the concrete
+        # runtime subclass (SiteApplication, ListModel, DatabaseDriver,
+        # HtmlDocument, MVCComponent, …), not on the interface/abstract PHPStan
+        # infers from the type-hint. Not real errors.
+        - '#Call to an undefined method Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel::#'
+        - '#Call to an undefined method Joomla\\CMS\\Application\\CMSApplicationInterface::#'
+        - '#Call to an undefined method Joomla\\Database\\DatabaseInterface::#'
+        - '#Call to an undefined method Joomla\\CMS\\Document\\Document::#'
+        - '#Call to an undefined method Joomla\\CMS\\Extension\\ComponentInterface::#'
+        - '#Call to an undefined method Joomla\\CMS\\Extension\\PluginInterface::#'
+        - '#Call to an undefined method Joomla\\CMS\\Language\\Language::#'
+        - '#Call to an undefined method Joomla\\CMS\\Form\\FormField::#'
+        - '#Call to an undefined method Joomla\\Session\\SessionInterface::#'
+
+        # libphonenumber (giggsey) is bundled with the tel field plugin, not in
+        # the scanned Joomla tree, so its symbols can't be resolved here.
+        - '#unknown class libphonenumber\\#'
+        - '#unknown class .*\\libphonenumber\\#'
 
     treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,15 @@ parameters:
         - plugins
         - modules
 
+    # The latest Joomla is downloaded into ./joomla in CI so PHPStan can resolve the
+    # Joomla\CMS\* / Joomla\* framework classes our code extends (the repo has no
+    # Composer dependencies). See .github/workflows/code-quality.yml.
+    scanDirectories:
+        - joomla
+
+    bootstrapFiles:
+        - .github/phpstan-bootstrap.php
+
     excludePaths:
         - */vendor/*
         - */tmpl/*
@@ -14,13 +23,8 @@ parameters:
         - */language/*
 
     ignoreErrors:
-        # Joomla framework classes are not available in CI (no Composer/stubs package).
-        # Suppress every framework-visibility error so PHPStan focuses on our own logic:
-        - identifier: class.notFound
-        - '#extends unknown class Joomla\\#'              # controllers/views extend Joomla\CMS base classes
-        - '#implements unknown interface Joomla\\#'
-        - '#but .+ does not extend any class#'            # parent::x() where the (unknown) parent is a Joomla class
-        # Joomla dynamic properties and magic methods
+        # Joomla models/views expose values via magic __get / dynamic methods,
+        # which PHPStan can't infer even with the framework scanned.
         - '#Access to an undefined property#'
         - '#Call to an undefined method.*\\\\HtmlView::#'
         - '#Call to an undefined method.*\\\\BaseController::#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,7 +17,6 @@ parameters:
         - .github/phpstan-bootstrap.php
 
     excludePaths:
-        - */vendor/*
         - */tmpl/*
         - */layouts/*
         - */language/*

--- a/scripts/phpstan-fetch-joomla.sh
+++ b/scripts/phpstan-fetch-joomla.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Populate ./joomla with the latest Joomla so PHPStan can resolve the framework
+# classes locally (CI does this automatically — see code-quality.yml).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+url=$(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest \
+  | python3 -c "import sys,json;print(next(a['browser_download_url'] for a in json.load(sys.stdin)['assets'] if a['name'].endswith('Full_Package.zip')))")
+echo "Fetching $url"
+curl -sL "$url" -o /tmp/joomla.zip
+rm -rf joomla && mkdir joomla && unzip -q /tmp/joomla.zip -d joomla
+echo "Joomla ready in ./joomla"


### PR DESCRIPTION
PHPStan analyses against the latest Joomla (scanDirectories + curated framework ignores + baseline of pre-existing findings); CI green, regressions flagged going forward. Review skill gains rules for heavy-logic-in-templates and hardcoded user-facing strings.