### PR TITLE
Event tiers: data / redirect / layout capability split

### DIFF
--- a/administrator/src/Event/General/GeneralEvent.php
+++ b/administrator/src/Event/General/GeneralEvent.php
@@ -14,15 +14,21 @@ namespace Alfa\Component\Alfa\Administrator\Event\General;
 
 use BadMethodCallException;
 use Joomla\CMS\Event\AbstractImmutableEvent;
-use Joomla\CMS\Router\Route;
-use Joomla\CMS\Uri\Uri;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * Class for CustomFields events
+ * Base event carrying only the subject (the order/cart/item the hook acts on).
+ *
+ * This is the "data" tier of the Alfa event hierarchy:
+ *   GeneralEvent (data only) → RedirectEvent (+ redirect) → LayoutEvent (+ layout)
+ *
+ * Pure side-effect / data hooks fired OUTSIDE any view — order place/save, shipping
+ * cost calculation — extend this, so they carry NO redirect and NO layout (a plugin
+ * cannot accidentally try to navigate from them). Hooks that may send the buyer
+ * somewhere extend RedirectEvent; view-rendered hooks extend LayoutEvent.
  *
  * @since  5.0.0
  */
@@ -69,122 +75,5 @@ abstract class GeneralEvent extends AbstractImmutableEvent
     protected function onSetSubject(object $value): object
     {
         return $value;
-    }
-
-    /**
-     * Set a redirect URL to be handled after the plugin finishes.
-     *
-     * @param string $url The URL to redirect to
-     *
-     * @since  5.0.0
-     */
-    public function onSetRedirectUrl(string $url): void
-    {
-        $this->setRedirectUrl($url);
-    }
-
-    /**
-     * Store the redirect URL raw (unrouted); SEF routing is deferred to getRedirectUrl().
-     *
-     * @param string $url The URL to redirect to
-     *
-     *
-     * @since  5.0.0
-     */
-    public function setRedirectUrl(string $url): void
-    {
-        // Store exactly what the plugin passes (raw). Routing to SEF happens lazily
-        // in getRedirectUrl(), so the event always keeps the original URL.
-        $this->arguments['redirectUrl'] = $url;
-    }
-
-    /**
-     * Get the redirect URL if one was set.
-     *
-     *
-     * @since  5.0.0
-     */
-    public function getRedirectUrl(): ?string
-    {
-        $url = $this->arguments['redirectUrl'] ?? null;
-
-        // SEF-route only RAW internal Joomla URLs: those on this site
-        // (Uri::isInternal — host check) AND still in raw "index.php?..." form
-        // (the only thing Route::_ can build a SEF link from). This lets a plugin
-        // set a plain "index.php?option=com_alfa&view=cart&layout=..." without
-        // calling Route::_() itself. External gateway URLs (host check fails) and
-        // already-final/SEF internal URLs (no "index.php") pass through unchanged,
-        // so they're never double-routed.
-        if (is_string($url) && str_contains($url, 'index.php') && Uri::isInternal($url)) {
-            return Route::_($url, false);
-        }
-
-        return $url;
-    }
-
-    /**
-     * Get the redirect URL exactly as the plugin set it — raw / unrouted.
-     *
-     * Use this when you need the original value (logging, or re-routing yourself
-     * with custom flags such as Route::TLS_FORCE / absolute). For redirecting,
-     * use getRedirectUrl(), which SEF-routes raw internal URLs.
-     */
-    public function getRawRedirectUrl(): ?string
-    {
-        return $this->arguments['redirectUrl'] ?? null;
-    }
-
-    /**
-     * Check whether a redirect URL has been set.
-     *
-     *
-     * @since  5.0.0
-     */
-    public function hasRedirect(): bool
-    {
-        return !empty($this->arguments['redirectUrl']);
-    }
-
-    /**
-     * Joomla event setter hook for the redirect HTTP status code — delegates to setRedirectCode().
-     *
-     * Common codes: 301 Moved Permanently, 302 Found, 303 See Other,
-     * 307 Temporary Redirect, 308 Permanent Redirect.
-     *
-     * @param int $code The HTTP status code to use for the redirect
-     *
-     * @return void
-     *
-     * @since  5.0.0
-     */
-    public function onSetRedirectCode(int $code)
-    {
-        $this->setRedirectCode($code);
-    }
-
-    /**
-     * Store the HTTP status code to use when the redirect is performed.
-     *
-     * @param int $code The HTTP status code
-     *
-     * @return void
-     *
-     * @since  5.0.0
-     */
-    public function setRedirectCode(int $code)
-    {
-        $this->arguments['redirectCode'] = $code;
-    }
-
-    /**
-     * Get the redirect HTTP status code if one was set.
-     *
-     * @return int|null The status code, or null when none was set
-     *
-     * @since  5.0.0
-     */
-    public function getRedirectCode(): ?int
-    {
-        return $this->arguments['redirectCode'] ?? null;
     }
 }

--- a/administrator/src/Event/General/LayoutEvent.php
+++ b/administrator/src/Event/General/LayoutEvent.php
@@ -24,11 +24,14 @@ use BadMethodCallException;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * Class for CustomFields events
+ * View tier: redirect + layout. Hooks rendered inside an HtmlView (cart, item,
+ * product, order process/complete, admin order views) extend this — they either
+ * render the plugin's layout fragment inline (setLayout) or send the buyer away
+ * (setRedirectUrl, inherited from RedirectEvent).
  *
  * @since  5.0.0
  */
-class LayoutEvent extends GeneralEvent //implements ResultAwareInterface
+class LayoutEvent extends RedirectEvent //implements ResultAwareInterface
 {
     //	use ResultAware;
     //	use ResultTypeStringAware;

--- a/administrator/src/Event/General/RedirectEvent.php
+++ b/administrator/src/Event/General/RedirectEvent.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Alfa Commerce
+ *
+ * @package    Alfa Commerce
+ * @author     Agamemnon Fakas <info@easylogic.gr>
+ * @copyright  (C) 2024-2026 Easylogic CO LP / Agamemnon Fakas. All rights reserved.
+ * @license    GNU General Public License version 3 or later; see LICENSE
+ */
+
+namespace Alfa\Component\Alfa\Administrator\Event\General;
+
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Base for events that may ask the component to redirect after the plugin runs.
+ *
+ * This is the "redirect" capability tier of the event hierarchy:
+ *   GeneralEvent (data only) → RedirectEvent (this) → LayoutEvent (redirect + layout)
+ *
+ * Use it for hooks fired outside a view whose only presentational power is to send
+ * the buyer somewhere (e.g. the gateway-return handler `onPaymentResponse`). Pure
+ * data/side-effect hooks (order place/save, shipping-cost calculation) must extend
+ * GeneralEvent instead, so they carry no redirect; view-rendered hooks extend
+ * LayoutEvent, which adds the layout capability on top of this one.
+ *
+ * @since  1.0.10
+ */
+abstract class RedirectEvent extends GeneralEvent
+{
+    /**
+     * Joomla event setter hook for the redirect URL — delegates to setRedirectUrl().
+     *
+     * @param string $url The URL to redirect to
+     *
+     * @since  5.0.0
+     */
+    public function onSetRedirectUrl(string $url): void
+    {
+        $this->setRedirectUrl($url);
+    }
+
+    /**
+     * Store the redirect URL raw (unrouted); SEF routing is deferred to getRedirectUrl().
+     *
+     * @param string $url The URL to redirect to
+     *
+     * @since  5.0.0
+     */
+    public function setRedirectUrl(string $url): void
+    {
+        // Store exactly what the plugin passes (raw). Routing to SEF happens lazily
+        // in getRedirectUrl(), so the event always keeps the original URL.
+        $this->arguments['redirectUrl'] = $url;
+    }
+
+    /**
+     * Get the redirect URL if one was set.
+     *
+     * @since  5.0.0
+     */
+    public function getRedirectUrl(): ?string
+    {
+        $url = $this->arguments['redirectUrl'] ?? null;
+
+        // SEF-route only RAW internal Joomla URLs: those on this site
+        // (Uri::isInternal — host check) AND still in raw "index.php?..." form
+        // (the only thing Route::_ can build a SEF link from). This lets a plugin
+        // set a plain "index.php?option=com_alfa&view=cart&layout=..." without
+        // calling Route::_() itself. External gateway URLs (host check fails) and
+        // already-final/SEF internal URLs (no "index.php") pass through unchanged,
+        // so they're never double-routed.
+        if (is_string($url) && str_contains($url, 'index.php') && Uri::isInternal($url)) {
+            return Route::_($url, false);
+        }
+
+        return $url;
+    }
+
+    /**
+     * Get the redirect URL exactly as the plugin set it — raw / unrouted.
+     *
+     * Use this when you need the original value (logging, or re-routing yourself
+     * with custom flags such as Route::TLS_FORCE / absolute). For redirecting,
+     * use getRedirectUrl(), which SEF-routes raw internal URLs.
+     */
+    public function getRawRedirectUrl(): ?string
+    {
+        return $this->arguments['redirectUrl'] ?? null;
+    }
+
+    /**
+     * Check whether a redirect URL has been set.
+     *
+     * @since  5.0.0
+     */
+    public function hasRedirect(): bool
+    {
+        return !empty($this->arguments['redirectUrl']);
+    }
+
+    /**
+     * Joomla event setter hook for the redirect HTTP status code — delegates to setRedirectCode().
+     *
+     * Common codes: 301 Moved Permanently, 302 Found, 303 See Other,
+     * 307 Temporary Redirect, 308 Permanent Redirect.
+     *
+     * @param int $code The HTTP status code to use for the redirect
+     *
+     * @return void
+     *
+     * @since  5.0.0
+     */
+    public function onSetRedirectCode(int $code)
+    {
+        $this->setRedirectCode($code);
+    }
+
+    /**
+     * Store the HTTP status code to use when the redirect is performed.
+     *
+     * @param int $code The HTTP status code
+     *
+     * @return void
+     *
+     * @since  5.0.0
+     */
+    public function setRedirectCode(int $code)
+    {
+        $this->arguments['redirectCode'] = $code;
+    }
+
+    /**
+     * Get the redirect HTTP status code if one was set.
+     *
+     * @return int|null The status code, or null when none was set
+     *
+     * @since  5.0.0
+     */
+    public function getRedirectCode(): ?int
+    {
+        return $this->arguments['redirectCode'] ?? null;
+    }
+}

--- a/administrator/src/Event/Payments/PaymentResponseEvent.php
+++ b/administrator/src/Event/Payments/PaymentResponseEvent.php
@@ -17,11 +17,13 @@ namespace Alfa\Component\Alfa\Administrator\Event\Payments;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * Class for CustomFields events
+ * Gateway-return event (onPaymentResponse), dispatched by the site PaymentController
+ * which has no view — so it is redirect-only (no layout). The plugin decides where to
+ * send the buyer after the bank; to show a result page, redirect to a view layout.
  *
  * @since  5.0.0
  */
-class PaymentResponseEvent extends PaymentsLayoutEvent
+class PaymentResponseEvent extends PaymentsRedirectEvent
 {
     /**
      * Get the order/cart subject carried by the event.

--- a/administrator/src/Event/Payments/PaymentsRedirectEvent.php
+++ b/administrator/src/Event/Payments/PaymentsRedirectEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @package    Alfa Commerce
+ * @author     Agamemnon Fakas <info@easylogic.gr>
+ * @copyright  (C) 2024-2026 Easylogic CO LP / Agamemnon Fakas. All rights reserved.
+ * @license    GNU General Public License version 3 or later; see LICENSE
+ */
+
+namespace Alfa\Component\Alfa\Administrator\Event\Payments;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Redirect tier for payment hooks fired outside a view — currently the gateway-return
+ * handler `onPaymentResponse`. The plugin may set a redirect (where to send the buyer
+ * after the bank); it renders no layout, because the controller that dispatches it has
+ * no view. To show something instead of redirecting, redirect to a view layout.
+ *
+ * @since  1.0.10
+ */
+abstract class PaymentsRedirectEvent extends \Alfa\Component\Alfa\Administrator\Event\General\RedirectEvent
+{
+}

--- a/administrator/src/Event/Shipments/ShipmentsRedirectEvent.php
+++ b/administrator/src/Event/Shipments/ShipmentsRedirectEvent.php
@@ -1,9 +1,6 @@
 <?php
 
 /**
- * Alfa Commerce
- *
- * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @package    Alfa Commerce
  * @author     Agamemnon Fakas <info@easylogic.gr>
  * @copyright  (C) 2024-2026 Easylogic CO LP / Agamemnon Fakas. All rights reserved.
@@ -17,21 +14,12 @@ namespace Alfa\Component\Alfa\Administrator\Event\Shipments;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * Class for CustomFields events
+ * Redirect tier for shipment hooks fired outside a view — the gateway/carrier-return
+ * handler `onPaymentResponse`. The plugin may set a redirect; it renders no layout,
+ * because the controller that dispatches it has no view.
  *
- * @since  5.0.0
+ * @since  1.0.10
  */
-class PaymentResponseEvent extends ShipmentsRedirectEvent
+abstract class ShipmentsRedirectEvent extends \Alfa\Component\Alfa\Administrator\Event\General\RedirectEvent
 {
-    /**
-     * Get the order/cart subject carried by the event.
-     *
-     * @return mixed The order or cart object
-     *
-     * @since  5.0.0
-     */
-    public function getOrder()
-    {
-        return $this->getSubject();
-    }
 }

--- a/changelog.xml
+++ b/changelog.xml
@@ -7,6 +7,7 @@
 
         <change>
             <item>Internal housekeeping: removed stray developer backup files that were inadvertently included in the package.</item>
+            <item>Refined the payment/shipment plugin event model so redirect and inline template rendering are available only where they apply — the checkout views and the gateway-return step; order place/save hooks are now strictly data hooks.</item>
         </change>
     </changelog>
 


### PR DESCRIPTION
Splits plugin event capabilities into 3 tiers (GeneralEvent data-only → RedirectEvent → LayoutEvent). onOrderAfterPlace and other place/save/calculate hooks are now plain (no inherited setRedirectUrl that was silently dropped); onPaymentResponse is redirect-only (its layout was never rendered). Resolves the reported 'after-place redirect doesn't work' as a wrong-hook usage — redirect to the gateway from onOrderProcessView. PHPStan green. Rides into unreleased 1.0.10.