### PR TITLE
Docs: PR merge protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,8 @@ Joomla component (type="component", method="upgrade") with bundled plugins and m
 - **Add a shipping method:** Create a new plugin under `/plugins/alfa-shipments/`, implement shipment event handlers
 - **Modify pricing logic:** See `PriceIndexSyncService` (admin) and `Pricing` service (site)
 - **Add API endpoint:** Create controller in `/api/src/Controller/`, view in `/api/src/View/`
+
+## Pull requests & merging
+- **Branch flow:** feature/fix branch → PR to `developer` → PR `developer` → `main` (release). Never commit directly to `developer`/`main` — the branch ruleset requires a PR.
+- **Wait for every check to finish before merging any PR** — on both the feature→`developer` and `developer`→`main` PRs. Checks: PHP CS Fixer, PHPStan, security-scan, CodeQL, secret-scanning, php-security, and the **Claude reviewer**. Read the Claude review summary + inline comments and fix anything raised, then merge. That pipeline (security audit + AI review) exists to catch bugs/regressions before they land; merging early defeats it and races the CS-Fixer auto-commit (causing protected-branch push failures and stray style commits).
+- Merging needs an admin override (review-required ruleset — the sole author can't self-approve), but only once all of the above is green.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,6 @@ Joomla component (type="component", method="upgrade") with bundled plugins and m
 - **Add API endpoint:** Create controller in `/api/src/Controller/`, view in `/api/src/View/`
 
 ## Pull requests & merging
-- **Branch flow:** feature/fix branch → PR to `developer` → PR `developer` → `main` (release). Never commit directly to `developer`/`main` — the branch ruleset requires a PR.
+- **Branch flow:** feature/fix branch → PR to `developer` → PR from `developer` → `main` (release). Never commit directly to `developer`/`main` — the branch ruleset requires a PR.
 - **Wait for every check to finish before merging any PR** — on both the feature→`developer` and `developer`→`main` PRs. Checks: PHP CS Fixer, PHPStan, security-scan, CodeQL, secret-scanning, php-security, and the **Claude reviewer**. Read the Claude review summary + inline comments and fix anything raised, then merge. That pipeline (security audit + AI review) exists to catch bugs/regressions before they land; merging early defeats it and races the CS-Fixer auto-commit (causing protected-branch push failures and stray style commits).
 - Merging needs an admin override (review-required ruleset — the sole author can't self-approve), but only once all of the above is green.


### PR DESCRIPTION
Documents that every CI check (CS Fixer, PHPStan, security-scan, CodeQL, secret-scanning, php-security) and the Claude reviewer must complete, and review comments be addressed, before merging any PR — on both the feature→developer and developer→main PRs.