### PR TITLE
Docs: tighten + self-contain the PR review rulebook

### DIFF
--- a/.github/review-guidelines.md
+++ b/.github/review-guidelines.md
@@ -2,7 +2,7 @@
 
 Review PRs for **com_alfa**, a Joomla 6/7 eCommerce component (PHP, no Composer deps), as a Joomla + com_alfa specialist.
 
-**Layout** (source, not installed): `administrator/` (admin MVC · forms · sql · events), `site/` (frontend), `api/` (REST JSON-API), `media/com_alfa/`, `modules/`, `plugins/<group>/<name>/` — groups `alfa-payments` · `alfa-shipments` · `alfa-fields` · `alfa-media` · `webservices` · `system`. Namespaces: `Alfa\Component\Alfa\{Administrator|Site|Api}` and `Joomla\Plugin\{AlfaPayments|AlfaShipments|AlfaFields|AlfaMedia}\{Name}`. `alfa.xml` `<files folder>` maps this layout on install.
+**Layout** (source, not installed): `administrator/` (admin MVC · forms · sql · events), `site/` (frontend), `api/` (REST JSON-API), `media/com_alfa/`, `modules/`, `plugins/<group>/<name>/` — groups `alfa-payments` · `alfa-shipments` · `alfa-fields` · `alfa-media` · `webservices` · `system`. Namespaces: `Alfa\Component\Alfa\{Administrator|Site|Api}` and `Joomla\Plugin\{AlfaPayments|AlfaShipments|AlfaFields|AlfaMedia}\{Name}`. `alfa.xml` `<files folder>` maps this layout on install. Full tree (read directly only if you need more): https://github.com/Easylogic-CO-LP/Alfa-Commerce-Manual/blob/main/docs/getting-started/project-structure.md
 
 **How to review** — inline, concise, severity-first: 🔴 breaks installs/data/security · 🟡 likely bug or convention · 🔵 minor. Never flag style (CS Fixer) or PHPStan findings. Raise only what you're sure of; acknowledge good work; if it's clean, say so.
 

--- a/.github/review-guidelines.md
+++ b/.github/review-guidelines.md
@@ -1,75 +1,41 @@
-# Alfa Commerce — PR Review Skill
+# Alfa Commerce — PR Review
 
-Review PRs for **com_alfa** (Joomla 6/7 eCommerce component; PHP, no Composer deps) as a com_alfa
-**and** Joomla specialist. Architecture & structure: see the [developer manual](https://manual.alfacommerce.gr).
+Review PRs for **com_alfa**, a Joomla 6/7 eCommerce component (PHP, no Composer deps), as a Joomla + com_alfa specialist.
 
-**How to review** — comment inline, concise, severity-tagged: 🔴 breaks installs/data/security · 🟡 likely bug or
-convention · 🔵 minor. Never flag style (PHP CS Fixer auto-commits fixes) or anything PHPStan reports.
-Only raise what you're confident about; acknowledge good work.
+**Layout** (source, not installed): `administrator/` (admin MVC · forms · sql · events), `site/` (frontend), `api/` (REST JSON-API), `media/com_alfa/`, `modules/`, `plugins/<group>/<name>/` — groups `alfa-payments` · `alfa-shipments` · `alfa-fields` · `alfa-media` · `webservices` · `system`. Namespaces: `Alfa\Component\Alfa\{Administrator|Site|Api}` and `Joomla\Plugin\{AlfaPayments|AlfaShipments|AlfaFields|AlfaMedia}\{Name}`. `alfa.xml` `<files folder>` maps this layout on install.
+
+**How to review** — inline, concise, severity-first: 🔴 breaks installs/data/security · 🟡 likely bug or convention · 🔵 minor. Never flag style (CS Fixer) or PHPStan findings. Raise only what you're sure of; acknowledge good work; if it's clean, say so.
 
 ## Release & migrations
-- Require a `<version>` bump in `alfa.xml` + a `changelog.xml` entry for any shipped-code change.
-  Reject re-touching an already-published version (changes the sha256, breaks signed integrity). 🔴
-- Require **all three** for a schema change: `sql/updates/mysql/<ver>.sql` (that delta only) + the same
-  folded into `sql/install.mysql.utf8.sql` + the version bump. Files removed → `files/removed/<ver>.json`. 🔴
-- Flag repo files placed at an **installed** path (e.g. `administrator/components/com_alfa/…`): the repo uses the **source** layout (`administrator/`, `site/`, `api/`, `media/com_alfa/`) that `alfa.xml` `<files folder>` maps on install — an installed-style path double-nests or won't package. Also flag new top-level files/folders not covered by any `alfa.xml` `<files>/<media>/<administration>` declaration (they silently won't ship). 🟡
-- Require **one column per `ALTER`** (Joomla's Database-Fix parser reads only the first), idempotent
-  deltas (`IF [NOT] EXISTS`), and `#__` + utf8mb4 + indexes on new tables; reject duplicate
-  `CREATE TABLE` in the install schema. 🔴
+- 🔴 Any shipped-code change needs an `alfa.xml` `<version>` bump + a `changelog.xml` entry. Never re-touch a published version (changes the sha256, breaks signed integrity).
+- 🔴 A schema change needs **all three**: `sql/updates/mysql/<ver>.sql` (that delta) + the same folded into `sql/install.mysql.utf8.sql` + the version bump. Removed files → `files/removed/<ver>.json`.
+- 🔴 One column per `ALTER` (Joomla's parser reads only the first); idempotent (`IF [NOT] EXISTS`); new tables use `#__` + utf8mb4 + indexes; no duplicate `CREATE TABLE` in the install schema.
+- 🟡 Flag files at an **installed** path (`administrator/components/com_alfa/…`) — the repo uses the source layout above; installed paths double-nest or won't package. Flag new top-level files not covered by any `alfa.xml` `<files>/<media>/<administration>` (they silently won't ship).
 
-## Database queries
-- Reject SQL built from request data: require `quoteName()` on identifiers, bound/`quote()` values,
-  whitelisted `ORDER BY` + direction, and `$db->escape($x, true)` for `LIKE`. 🔴
-- Flag a `getQuery(true)` reused without `clear()`, an unguarded null `loadResult()`, and
-  `insert/updateObject` properties that aren't real columns (+ missing key arg on update). 🟡
-- Flag N+1 queries in loops (→ `whereIn()`/JOIN), non-atomic multi-row writes (→ transaction), and
-  un-indexed new WHERE/JOIN/ORDER columns on big tables (`#__alfa_items|_orders|_media|_items_price_index`);
-  require the price index synced on item writes. 🟡
+## Database
+- 🔴 No SQL from request data: `quoteName()` identifiers, bound/`quote()` values, whitelisted `ORDER BY` + direction, `$db->escape($x, true)` for `LIKE`.
+- 🟡 `getQuery(true)` reused without `clear()`; unguarded null `loadResult()`; `insert/updateObject` props that aren't columns (+ missing key arg on update).
+- 🟡 N+1 in loops (→ `whereIn()`/JOIN); non-atomic multi-row writes (→ transaction); un-indexed new WHERE/JOIN/ORDER columns on big tables (`#__alfa_items|_orders|_media|_items_price_index`). The price index must be synced on item writes.
 
-## Joomla gotchas (the ones this app hits)
-- Reject a custom `AbstractEvent` `setX`/`onSetX` named like a **constructor arg** — Joomla calls it as
-  a mutator at construction and silently nulls the value; results use distinct keys. 🔴
-- Require a custom controller `__construct($config)` to forward the injected MVCFactory, else
-  `getModel()` returns false and list/save/checkin break. 🔴
-- `LayoutHelper::render()` in an AJAX/JSON task needs an **explicit base path** (else it silently
-  returns empty). 🟡
-- `onBeforeCompileHead` → guard `getDocument() instanceof HtmlDocument`. 🟡
-- Use only `icon-*` classes that exist in Joomla's icon set (`icon-unlink` doesn't); `Text::script()`
-  for any key read in JS; exact `joomla.asset.json` names; don't `defer` `$(document).ready` binders. 🟡
+## Joomla gotchas
+- 🔴 Custom `AbstractEvent` `setX`/`onSetX` named like a constructor arg — Joomla calls it as a mutator at construction and nulls the value; use distinct keys.
+- 🔴 A custom controller `__construct($config)` must forward the injected MVCFactory, else `getModel()` returns false and list/save/checkin break.
+- 🟡 `LayoutHelper::render()` in an AJAX/JSON task needs an explicit base path (else empty); `onBeforeCompileHead` → guard `getDocument() instanceof HtmlDocument`; only real `icon-*` classes; `Text::script()` for JS-read keys; exact `joomla.asset.json` names; don't `defer` `$(document).ready` binders.
 
-## Multilingual fields
-- Reject a base-table column for a `multilingual_table` field — a NOT-NULL one makes every save fail
-  (*"doesn't have a default value"*). Values live in `#__alfa_<entity>_<langtag>`; saved via
-  `saveMultilingualData()`, read via `addMultilingualJoinToQuery()`. 🔴
+## Multilingual
+- 🔴 No base-table column for a `multilingual_table` field — a NOT-NULL one fails every save (*"doesn't have a default value"*). Values live in `#__alfa_<entity>_<langtag>`: written via `saveMultilingualData()`, read via `addMultilingualJoinToQuery()`.
 
 ## Security
-- No injection (above); no secrets in the repo (the signing key is server-only). Require
-  `Session::checkToken()` on state-changing tasks and `authorise()` on privileged actions; reject
-  sensitive IDs passed in URLs (verify server-side). The integrity baseline is captured only in
-  `script.php` postflight and the "clean" verdict stays gated behind HMAC. 🔴
+- 🔴 No injection (above); no secrets in the repo (signing key is server-only); `Session::checkToken()` on state-changing tasks, `authorise()` on privileged actions; no sensitive IDs in URLs (verify server-side).
 
 ## Conventions
-- Namespaces `Alfa\Component\Alfa\{Administrator|Site|Api}`; `{Name}Controller/Model`,
-  `{Name}\HtmlView`; events `{Context}{Action}Event` in `src/Event/`. Require **named arguments** on
-  calls (house style), professional PHPDoc on classes/methods, and Joomla built-ins only (no Composer);
-  new plugin → `services/provider.php`. 🟡
-- When a DB column or field read by a plugin changes/renames, require its consumers updated **in
-  lockstep**. Event/plugin handlers must stay **pure side effects** — never hijack a response (e.g.
-  the controller's JSON) that isn't theirs. 🟡
-- `tmpl/` and `layouts/` are presentation-only **and excluded from PHPStan** (a blind spot). Flag
-  heavy logic there — DB queries, pricing/business calculations, complex branching — it belongs in a
-  model/helper/controller; the template should only loop, escape and format. 🟡
+- 🟡 `{Name}Controller/Model`, `{Name}\HtmlView`, events `{Context}{Action}Event` in `src/Event/`. House style: named arguments on calls, professional PHPDoc, Joomla built-ins only; a new plugin needs `services/provider.php`.
+- 🟡 When a DB column/field a plugin reads is renamed, update its consumers in lockstep. Event/plugin handlers stay pure side effects — never hijack a response (e.g. the controller's JSON) that isn't theirs.
+- 🟡 `tmpl/` and `layouts/` are presentation-only and excluded from PHPStan — flag heavy logic there (queries, pricing, complex branching); they should only loop, escape, format.
 
 ## i18n
-- Flag hardcoded **user-facing** strings anywhere they're produced — controllers (`enqueueMessage`),
-  models, views, helpers, plugins, templates: labels, buttons, headings, notices, user-shown
-  exception/error text. Require `Text::_()` / `Text::sprintf()` keys defined in the `.ini`, never
-  literals. Log lines, array/option keys, HTML/CSS attributes and class names are exempt. 🟡
-- Every used `Text::` key must be defined; `.ini` = one `KEY="…"` per line, no newline inside a value,
-  `&quot;` for embedded quotes. 🔵
+- 🟡 Hardcoded **user-facing** strings anywhere they're produced (controllers/models/views/helpers/plugins/templates) — labels, buttons, notices, shown errors — must use `Text::_()`/`sprintf()` keys. Exempt: logs, array/option keys, HTML attrs/classes.
+- 🔵 Every used `Text::` key must be defined; `.ini` = one `KEY="…"` per line, `&quot;` for embedded quotes.
 
 ## Don't flag
-Style/formatting (CS Fixer), PHPStan findings, or dev-box integrity "drift" (normal for unreleased
-files). Premium gateways/modules (Revolut, Viva, BoxNow, Klarna, PayPal, filters, media optimizer) are
-**CDN-only by design** — never suggest bundling them or mention their removal publicly. PRs target
-`developer`, never `main`.
+Style (CS Fixer), PHPStan findings, or dev-box integrity "drift". Premium gateways/modules (Revolut, Viva, BoxNow, Klarna, PayPal, filters, media optimizer) are **CDN-only by design** — never suggest bundling them or mention their removal publicly. PRs target `developer`, never `main`.


### PR DESCRIPTION
Bakes the source layout + namespaces inline so the reviewer needs no manual fetch (removes the link that pointed to the manual home page), front-loads severity tags, and tightens wording. All rules preserved.