### PR TITLE
Docs: bake full project structure into the PR reviewer

### DIFF
--- a/.github/review-guidelines.md
+++ b/.github/review-guidelines.md
@@ -2,9 +2,124 @@
 
 Review PRs for **com_alfa**, a Joomla 6/7 eCommerce component (PHP, no Composer deps), as a Joomla + com_alfa specialist.
 
-**Layout** (source, not installed): `administrator/` (admin MVC · forms · sql · events), `site/` (frontend), `api/` (REST JSON-API), `media/com_alfa/`, `modules/`, `plugins/<group>/<name>/` — groups `alfa-payments` · `alfa-shipments` · `alfa-fields` · `alfa-media` · `webservices` · `system`. Namespaces: `Alfa\Component\Alfa\{Administrator|Site|Api}` and `Joomla\Plugin\{AlfaPayments|AlfaShipments|AlfaFields|AlfaMedia}\{Name}`. `alfa.xml` `<files folder>` maps this layout on install. Full tree (read directly only if you need more): https://github.com/Easylogic-CO-LP/Alfa-Commerce-Manual/blob/main/docs/getting-started/project-structure.md
-
 **How to review** — inline, concise, severity-first: 🔴 breaks installs/data/security · 🟡 likely bug or convention · 🔵 minor. Never flag style (CS Fixer) or PHPStan findings. Raise only what you're sure of; acknowledge good work; if it's clean, say so.
+
+## Project structure
+
+Source layout (not the installed layout — `alfa.xml` `<files folder>` maps it on install):
+
+```
+Alfa-Commerce/
+├── administrator/              # Backend admin panel
+│   ├── src/
+│   │   ├── Extension/          # Component bootstrap (AlfaComponent.php)
+│   │   ├── Controller/         # Admin controllers (Form + List)
+│   │   ├── Model/              # Admin models (CRUD, queries)
+│   │   ├── View/               # Admin views (36+ view classes)
+│   │   ├── Table/              # Database table classes
+│   │   ├── Field/              # Custom form field types
+│   │   ├── Helper/             # Business logic helpers
+│   │   ├── Service/            # Services (PriceIndexSyncService)
+│   │   ├── Event/              # Event classes (40+ events)
+│   │   └── Plugin/             # Base plugin classes
+│   ├── forms/                  # XML form definitions (39 forms)
+│   ├── tmpl/                   # Admin HTML templates
+│   ├── sql/                    # Database schemas & migrations
+│   │   ├── install.mysql.utf8.sql
+│   │   ├── uninstall.mysql.utf8.sql
+│   │   └── updates/mysql/      # Version migration scripts (e.g. 1.0.9.sql)
+│   ├── services/               # DI container (provider.php)
+│   ├── layouts/                # Reusable template layouts
+│   ├── languages/              # Localization (en-GB)
+│   ├── config.xml              # Component configuration form
+│   └── access.xml              # ACL permissions
+│
+├── site/                       # Frontend customer-facing
+│   ├── src/
+│   │   ├── Controller/         # Frontend controllers
+│   │   ├── Model/              # Frontend models
+│   │   ├── View/               # Frontend views
+│   │   ├── Service/            # Pricing engine
+│   │   │   └── Pricing/        # Money, PriceResult, PriceContext, etc.
+│   │   ├── Helper/             # CartHelper, OrderPlaceHelper, PriceSettings
+│   │   └── Dispatcher/         # Request dispatcher
+│   ├── forms/                  # Frontend forms
+│   ├── tmpl/                   # Frontend templates
+│   └── languages/              # Frontend localization
+│
+├── api/                        # REST JSON-API
+│   └── src/
+│       ├── Controller/         # REST API controllers
+│       └── View/               # JSON response views
+│
+├── plugins/                    # Core ships only the `standard` reference plugins;
+│   │                           # real gateways/carriers are premium (distributed separately)
+│   ├── alfa-payments/
+│   │   └── standard/           # Offline payment (bank transfer / cash on delivery)
+│   ├── alfa-shipments/
+│   │   └── standard/           # Standard shipping (flat / zone rates)
+│   ├── alfa-fields/            # Form field type plugins
+│   │   ├── text/
+│   │   ├── textarea/
+│   │   ├── tel/
+│   │   └── choice/
+│   ├── webservices/alfa/       # API route registration
+│   └── system/alfasync/        # Post-install integrity & per-language schema sync
+│
+├── modules/
+│   ├── mod_alfa_cart/           # Shopping cart widget module
+│   └── mod_alfa_search/         # Product search module
+│
+├── media/com_alfa/              # Static assets
+│   ├── css/                     # Stylesheets (admin + site)
+│   ├── js/                      # JavaScript (admin + site)
+│   ├── images/                  # Component images
+│   └── joomla.asset.json        # Joomla asset registry
+│
+├── alfa.xml                     # Package manifest
+├── script.php                   # Install/update/uninstall script
+├── .php-cs-fixer.php            # Code style configuration
+├── phpstan.neon                 # Static analysis configuration
+├── CONTRIBUTING.md              # Contribution guide
+└── .github/workflows/           # CI/CD automation
+```
+
+### Namespaces (PSR-4, Joomla 6/7)
+
+| Part | Namespace |
+|------|-----------|
+| Admin | `Alfa\Component\Alfa\Administrator\{Controller,Model,View,...}` |
+| Site | `Alfa\Component\Alfa\Site\{Controller,Model,View,...}` |
+| API | `Alfa\Component\Alfa\Api\{Controller,View}` |
+| Payment plugins | `Joomla\Plugin\AlfaPayments\{PluginName}\Extension` |
+| Shipment plugins | `Joomla\Plugin\AlfaShipments\{PluginName}\Extension` |
+| Field plugins | `Joomla\Plugin\AlfaFields\{PluginName}\Extension` |
+| Cart module | `Alfa\Module\AlfaCart` |
+| Search module | `Alfa\Module\AlfaSearch` |
+
+### Naming
+
+| Pattern | Example |
+|---------|---------|
+| Controllers | `ItemController`, `ItemsController` |
+| Models | `ItemModel`, `CategoriesModel` |
+| Views | `Items\HtmlView`, `Items\JsonapiView` |
+| Tables | `ItemTable` |
+| Events | `AdminOrderViewEvent`, `PaymentResponseEvent` |
+| Helpers | `CartHelper`, `OrderPaymentHelper` |
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `administrator/services/provider.php` | DI container — registers all component services |
+| `administrator/src/Extension/AlfaComponent.php` | Component bootstrap class |
+| `site/src/Helper/CartHelper.php` | Shopping cart logic |
+| `site/src/Helper/OrderPlaceHelper.php` | Order placement flow |
+| `site/src/Service/Pricing/` | Complete pricing engine |
+| `administrator/src/Event/` | All event classes |
+| `administrator/src/Plugin/` | Base plugin classes (Plugin, PaymentsPlugin, ShipmentsPlugin) |
+| `administrator/sql/install.mysql.utf8.sql` | Complete database schema |
 
 ## Release & migrations
 - 🔴 Any shipped-code change needs an `alfa.xml` `<version>` bump + a `changelog.xml` entry. Never re-touch a published version (changes the sha256, breaks signed integrity).


### PR DESCRIPTION
Copies the canonical project-structure (tree + namespaces + naming + key files) inline into review-guidelines.md so the reviewer is fully self-contained — no link, no fetch. Dropped the stale CLAUDE.md tree line (file was removed).