### PR TITLE
Docs: remove placeholder Supported Versions table from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,5 @@
 # Security Policy
 
-## Supported Versions
-
-| Version | Supported |
-|---------|-----------|
-| Pre-alpha (current) | Yes |
-
 ## Reporting a Vulnerability
 
 We take security seriously at Alfa Commerce. If you discover a security vulnerability, please report it responsibly.


### PR DESCRIPTION
Drops the single-row 'Pre-alpha (current) | Yes' table; the policy goes straight to how to report a vulnerability.