### PR TITLE
Docs: SECURITY.md — remove placeholder Supported Versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,5 @@
 # Security Policy
 
-## Supported Versions
-
-| Version | Supported |
-|---------|-----------|
-| Pre-alpha (current) | Yes |
-
 ## Reporting a Vulnerability
 
 We take security seriously at Alfa Commerce. If you discover a security vulnerability, please report it responsibly.


### PR DESCRIPTION
Promotes the SECURITY.md cleanup to main so GitHub's Security tab reflects it. Docs-only, no version bump.