### PR TITLE
Standardize plugin namespaces to Alfa\ prefix (v1.2.0)

### DIFF
--- a/.github/review-guidelines.md
+++ b/.github/review-guidelines.md
@@ -153,4 +153,4 @@ Alfa-Commerce/
 - 🔵 Every used `Text::` key must be defined; `.ini` = one `KEY="…"` per line, `&quot;` for embedded quotes.
 
 ## Don't flag
-Style (CS Fixer), PHPStan findings, or dev-box integrity "drift". Premium gateways/modules (Revolut, Viva, BoxNow, Klarna, PayPal, filters, media optimizer) are **CDN-only by design** — never suggest bundling them or mention their removal publicly. PRs target `developer`, never `main`.
+Style (CS Fixer), PHPStan findings, or dev-box integrity "drift". PRs target `developer`, never `main`.

--- a/.github/review-guidelines.md
+++ b/.github/review-guidelines.md
@@ -91,9 +91,9 @@ Alfa-Commerce/
 | Admin | `Alfa\Component\Alfa\Administrator\{Controller,Model,View,...}` |
 | Site | `Alfa\Component\Alfa\Site\{Controller,Model,View,...}` |
 | API | `Alfa\Component\Alfa\Api\{Controller,View}` |
-| Payment plugins | `Joomla\Plugin\AlfaPayments\{PluginName}\Extension` |
-| Shipment plugins | `Joomla\Plugin\AlfaShipments\{PluginName}\Extension` |
-| Field plugins | `Joomla\Plugin\AlfaFields\{PluginName}\Extension` |
+| Payment plugins | `Alfa\Plugin\AlfaPayments\{PluginName}\Extension` |
+| Shipment plugins | `Alfa\Plugin\AlfaShipments\{PluginName}\Extension` |
+| Field plugins | `Alfa\Plugin\AlfaFields\{PluginName}\Extension` |
 | Cart module | `Alfa\Module\AlfaCart` |
 | Search module | `Alfa\Module\AlfaSearch` |
 

--- a/alfa.xml
+++ b/alfa.xml
@@ -7,7 +7,7 @@
     <author>Agamemnon Fakas</author>
     <authorEmail>info@easylogic.gr</authorEmail>
     <authorUrl>https://easylogic.gr</authorUrl>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <description>The smartest,fastest and easiest ecommerce solution for companies developed with love by Easylogic.</description>
     <namespace path="src">Alfa\Component\Alfa</namespace>
 

--- a/changelog.xml
+++ b/changelog.xml
@@ -3,6 +3,15 @@
     <changelog>
         <element>com_alfa</element>
         <type>component</type>
+        <version>1.2.0</version>
+
+        <change>
+            <item>Standardised every bundled plugin namespace to the Alfa\ vendor prefix (alfa-shipments and alfa-payments Standard, and the alfa-fields plugins). Internal refactor only — no schema change and no effect on stored data.</item>
+        </change>
+    </changelog>
+    <changelog>
+        <element>com_alfa</element>
+        <type>component</type>
         <version>1.1.0</version>
 
         <change>

--- a/plugins/alfa-fields/choice/choice.xml
+++ b/plugins/alfa-fields/choice/choice.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 3 or later; see LICENSE</license>
     <version>1.0.0</version>
     <description>PLG_ALFA_FIELDS_CHOICE_DESC</description>
-    <namespace path="src">Joomla\Plugin\AlfaFields\Choice</namespace>
+    <namespace path="src">Alfa\Plugin\AlfaFields\Choice</namespace>
     <files>
         <folder>params</folder>
         <folder plugin="choice">services</folder>

--- a/plugins/alfa-fields/choice/services/provider.php
+++ b/plugins/alfa-fields/choice/services/provider.php
@@ -2,12 +2,12 @@
 
 defined('_JEXEC') or die;
 
+use Alfa\Plugin\AlfaFields\Choice\Extension\Choice;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Alfa\Plugin\AlfaFields\Choice\Extension\Choice;
 
 // Events are auto-wired from Choice::getSubscribedEvents() via SubscriberInterface
 // (declared on FieldsPlugin). Do NOT call $dispatcher->addListener() here — that

--- a/plugins/alfa-fields/choice/services/provider.php
+++ b/plugins/alfa-fields/choice/services/provider.php
@@ -7,7 +7,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Joomla\Plugin\AlfaFields\Choice\Extension\Choice;
+use Alfa\Plugin\AlfaFields\Choice\Extension\Choice;
 
 // Events are auto-wired from Choice::getSubscribedEvents() via SubscriberInterface
 // (declared on FieldsPlugin). Do NOT call $dispatcher->addListener() here — that

--- a/plugins/alfa-fields/choice/src/Extension/Choice.php
+++ b/plugins/alfa-fields/choice/src/Extension/Choice.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Joomla\Plugin\AlfaFields\Choice\Extension;
+namespace Alfa\Plugin\AlfaFields\Choice\Extension;
 
 use Alfa\Component\Alfa\Administrator\Event\Fields\PrepareDomEvent;
 use Alfa\Component\Alfa\Administrator\Plugin\FieldsPlugin;
@@ -99,7 +99,7 @@ final class Choice extends FieldsPlugin
                 $node->setAttribute('data-max-selections', (string) $maxSel);
             }
             $node->setAttribute('validate', 'choice');
-            FormHelper::addRulePrefix('Joomla\\Plugin\\AlfaFields\\Choice\\Rule');
+            FormHelper::addRulePrefix('Alfa\\Plugin\\AlfaFields\\Choice\\Rule');
 
             // Joomla's validate.js dispatches handlers via class="validate-X",
             // not the validate="X" attribute (server-side only). Without this
@@ -117,7 +117,7 @@ final class Choice extends FieldsPlugin
 
         // Button variants need a class prefix + custom params forwarded as attrs.
         if (in_array($type, ['button', 'buttonmulti'], true)) {
-            FormHelper::addFieldPrefix('Joomla\\Plugin\\AlfaFields\\Choice\\Field');
+            FormHelper::addFieldPrefix('Alfa\\Plugin\\AlfaFields\\Choice\\Field');
             $node->setAttribute('button_style', $variant);
             $node->setAttribute('layout_mode', $layoutMod);
         }

--- a/plugins/alfa-fields/choice/src/Field/ButtonField.php
+++ b/plugins/alfa-fields/choice/src/Field/ButtonField.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Joomla\Plugin\AlfaFields\Choice\Field;
+namespace Alfa\Plugin\AlfaFields\Choice\Field;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\RadioField;

--- a/plugins/alfa-fields/choice/src/Field/ButtonmultiField.php
+++ b/plugins/alfa-fields/choice/src/Field/ButtonmultiField.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Joomla\Plugin\AlfaFields\Choice\Field;
+namespace Alfa\Plugin\AlfaFields\Choice\Field;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\CheckboxesField;

--- a/plugins/alfa-fields/choice/src/Rule/ChoiceRule.php
+++ b/plugins/alfa-fields/choice/src/Rule/ChoiceRule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Joomla\Plugin\AlfaFields\Choice\Rule;
+namespace Alfa\Plugin\AlfaFields\Choice\Rule;
 
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormRule;

--- a/plugins/alfa-fields/tel/services/provider.php
+++ b/plugins/alfa-fields/tel/services/provider.php
@@ -7,7 +7,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Joomla\Plugin\AlfaFields\Tel\Extension\Tel;
+use Alfa\Plugin\AlfaFields\Tel\Extension\Tel;
 
 // Events are auto-wired from Tel::getSubscribedEvents() (inherited empty default
 // from FieldsPlugin via SubscriberInterface). Do NOT pass a DispatcherInterface

--- a/plugins/alfa-fields/tel/services/provider.php
+++ b/plugins/alfa-fields/tel/services/provider.php
@@ -2,12 +2,12 @@
 
 defined('_JEXEC') or die;
 
+use Alfa\Plugin\AlfaFields\Tel\Extension\Tel;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Alfa\Plugin\AlfaFields\Tel\Extension\Tel;
 
 // Events are auto-wired from Tel::getSubscribedEvents() (inherited empty default
 // from FieldsPlugin via SubscriberInterface). Do NOT pass a DispatcherInterface

--- a/plugins/alfa-fields/tel/src/Extension/Tel.php
+++ b/plugins/alfa-fields/tel/src/Extension/Tel.php
@@ -7,7 +7,7 @@
  * @license    GNU General Public License version 3 or later; see LICENSE
  */
 
-namespace Joomla\Plugin\AlfaFields\Tel\Extension;
+namespace Alfa\Plugin\AlfaFields\Tel\Extension;
 
 use Alfa\Component\Alfa\Administrator\Event\Fields\PrepareDomEvent;
 use Alfa\Component\Alfa\Administrator\Plugin\FieldsPlugin;
@@ -40,7 +40,7 @@ final class Tel extends FieldsPlugin
         // Our own field class — wraps the input in a layout that pre-renders
         // translated hint <small> elements that tel.js toggles.
         $node->setAttribute('type', 'tel');
-        FormHelper::addFieldPrefix('Joomla\\Plugin\\AlfaFields\\Tel\\Field');
+        FormHelper::addFieldPrefix('Alfa\\Plugin\\AlfaFields\\Tel\\Field');
 
         // Single source of truth for the rule name. Keep it lowercase —
         // camelCase breaks FormHelper::loadClass (splits into sub-namespace).
@@ -83,7 +83,7 @@ final class Tel extends FieldsPlugin
         $node->setAttribute('data-require-mobile', $require_mobile);
         $node->setAttribute('data-display-format', $display_format);
 
-        FormHelper::addRulePrefix('Joomla\\Plugin\\AlfaFields\\Tel\\Rule');
+        FormHelper::addRulePrefix('Alfa\\Plugin\\AlfaFields\\Tel\\Rule');
 
         return $node;
     }

--- a/plugins/alfa-fields/tel/src/Field/TelField.php
+++ b/plugins/alfa-fields/tel/src/Field/TelField.php
@@ -7,7 +7,7 @@
  * @license    GNU General Public License version 3 or later; see LICENSE
  */
 
-namespace Joomla\Plugin\AlfaFields\Tel\Field;
+namespace Alfa\Plugin\AlfaFields\Tel\Field;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\TextField;

--- a/plugins/alfa-fields/tel/src/Rule/AlfatelRule.php
+++ b/plugins/alfa-fields/tel/src/Rule/AlfatelRule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Joomla\Plugin\AlfaFields\Tel\Rule;
+namespace Alfa\Plugin\AlfaFields\Tel\Rule;
 
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormRule;

--- a/plugins/alfa-fields/tel/tel.xml
+++ b/plugins/alfa-fields/tel/tel.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 3 or later</license>
     <version>1.0.0</version>
     <description>PLG_ALFA_FIELDS_TEL_XML_DESCRIPTION</description>
-    <namespace path="src">Joomla\Plugin\AlfaFields\Tel</namespace>
+    <namespace path="src">Alfa\Plugin\AlfaFields\Tel</namespace>
     <files>
         <folder>params</folder>
         <folder plugin="tel">services</folder>

--- a/plugins/alfa-fields/text/services/provider.php
+++ b/plugins/alfa-fields/text/services/provider.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
-use Joomla\Plugin\AlfaFields\Text\Extension\Text;
+use Alfa\Plugin\AlfaFields\Text\Extension\Text;
 
 return new class () implements ServiceProviderInterface {
     /**

--- a/plugins/alfa-fields/text/services/provider.php
+++ b/plugins/alfa-fields/text/services/provider.php
@@ -11,13 +11,13 @@
 
 \defined('_JEXEC') or die;
 
+use Alfa\Plugin\AlfaFields\Text\Extension\Text;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
-use Alfa\Plugin\AlfaFields\Text\Extension\Text;
 
 return new class () implements ServiceProviderInterface {
     /**

--- a/plugins/alfa-fields/text/src/Extension/Text.php
+++ b/plugins/alfa-fields/text/src/Extension/Text.php
@@ -7,7 +7,7 @@
  * @license    GNU General Public License version 3 or later; see LICENSE
  */
 
-namespace Joomla\Plugin\AlfaFields\Text\Extension;
+namespace Alfa\Plugin\AlfaFields\Text\Extension;
 
 use Alfa\Component\Alfa\Administrator\Plugin\FieldsPlugin;
 

--- a/plugins/alfa-fields/text/text.xml
+++ b/plugins/alfa-fields/text/text.xml
@@ -9,7 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.7.0</version>
 	<description>PLG_ALFA_FIELDS_TEXT_XML_DESCRIPTION</description>
-	<namespace path="src">Joomla\Plugin\AlfaFields\Text</namespace>
+	<namespace path="src">Alfa\Plugin\AlfaFields\Text</namespace>
 	<files>
 		<folder>params</folder>
 		<folder plugin="text">services</folder>

--- a/plugins/alfa-fields/textarea/services/provider.php
+++ b/plugins/alfa-fields/textarea/services/provider.php
@@ -11,13 +11,13 @@
 
 \defined('_JEXEC') or die;
 
+use Alfa\Plugin\AlfaFields\Textarea\Extension\Textarea;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
-use Alfa\Plugin\AlfaFields\Textarea\Extension\Textarea;
 
 return new class () implements ServiceProviderInterface {
     /**

--- a/plugins/alfa-fields/textarea/services/provider.php
+++ b/plugins/alfa-fields/textarea/services/provider.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
-use Joomla\Plugin\AlfaFields\Textarea\Extension\Textarea;
+use Alfa\Plugin\AlfaFields\Textarea\Extension\Textarea;
 
 return new class () implements ServiceProviderInterface {
     /**

--- a/plugins/alfa-fields/textarea/src/Extension/Textarea.php
+++ b/plugins/alfa-fields/textarea/src/Extension/Textarea.php
@@ -7,7 +7,7 @@
  * @license    GNU General Public License version 3 or later; see LICENSE
  */
 
-namespace Joomla\Plugin\AlfaFields\Textarea\Extension;
+namespace Alfa\Plugin\AlfaFields\Textarea\Extension;
 
 use Alfa\Component\Alfa\Administrator\Plugin\FieldsPlugin;
 

--- a/plugins/alfa-fields/textarea/textarea.xml
+++ b/plugins/alfa-fields/textarea/textarea.xml
@@ -9,7 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.7.0</version>
 	<description>PLG_ALFA_FIELDS_TEXTAREA_XML_DESCRIPTION</description>
-	<namespace path="src">Joomla\Plugin\AlfaFields\Textarea</namespace>
+	<namespace path="src">Alfa\Plugin\AlfaFields\Textarea</namespace>
 	<files>
 		<folder>params</folder>
 		<folder plugin="textarea">services</folder>

--- a/plugins/alfa-payments/standard/services/provider.php
+++ b/plugins/alfa-payments/standard/services/provider.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Joomla\Plugin\AlfaPayments\Standard\Extension\Standard;
+use Alfa\Plugin\AlfaPayments\Standard\Extension\Standard;
 
 return new class () implements ServiceProviderInterface {
     /**

--- a/plugins/alfa-payments/standard/services/provider.php
+++ b/plugins/alfa-payments/standard/services/provider.php
@@ -13,12 +13,12 @@
 
 \defined('_JEXEC') or die;
 
+use Alfa\Plugin\AlfaPayments\Standard\Extension\Standard;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Alfa\Plugin\AlfaPayments\Standard\Extension\Standard;
 
 return new class () implements ServiceProviderInterface {
     /**

--- a/plugins/alfa-payments/standard/src/Extension/Standard.php
+++ b/plugins/alfa-payments/standard/src/Extension/Standard.php
@@ -254,7 +254,7 @@
  *
  * 1. Copy the entire plugins/alfa-payments/standard/ directory
  * 2. Rename to plugins/alfa-payments/yourname/
- * 3. Update namespace: Joomla\Plugin\AlfaPayments\YourName\Extension
+ * 3. Update namespace: Alfa\Plugin\AlfaPayments\YourName\Extension
  * 4. Rename class: final class YourName extends PaymentsPlugin
  * 5. Update services/provider.php with new class reference
  * 6. Update language files and XML manifest
@@ -296,7 +296,7 @@
  * @since  1.0.0
  */
 
-namespace Joomla\Plugin\AlfaPayments\Standard\Extension;
+namespace Alfa\Plugin\AlfaPayments\Standard\Extension;
 
 use Alfa\Component\Alfa\Administrator\Helper\OrderPaymentHelper;
 use Alfa\Component\Alfa\Administrator\Plugin\PaymentsPlugin;

--- a/plugins/alfa-payments/standard/standard.xml
+++ b/plugins/alfa-payments/standard/standard.xml
@@ -11,7 +11,7 @@
 	<authorUrl>http://easylogic.gr</authorUrl>
 	<version>1.0.2</version>
 	<description>PLG_ALFA_PAYMENTS_STANDARD_XML_DESCRIPTION</description>
-	<namespace path="src">Joomla\Plugin\AlfaPayments\Standard</namespace>
+	<namespace path="src">Alfa\Plugin\AlfaPayments\Standard</namespace>
 	<files>
 		<folder plugin="standard">services</folder>
 		<folder>src</folder>

--- a/plugins/alfa-shipments/standard/services/provider.php
+++ b/plugins/alfa-shipments/standard/services/provider.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Joomla\Plugin\AlfaShipments\Standard\Extension\Standard;
+use Alfa\Plugin\AlfaShipments\Standard\Extension\Standard;
 
 return new class () implements ServiceProviderInterface {
     /**

--- a/plugins/alfa-shipments/standard/services/provider.php
+++ b/plugins/alfa-shipments/standard/services/provider.php
@@ -13,12 +13,12 @@
 
 \defined('_JEXEC') or die;
 
+use Alfa\Plugin\AlfaShipments\Standard\Extension\Standard;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Alfa\Plugin\AlfaShipments\Standard\Extension\Standard;
 
 return new class () implements ServiceProviderInterface {
     /**

--- a/plugins/alfa-shipments/standard/src/Extension/Standard.php
+++ b/plugins/alfa-shipments/standard/src/Extension/Standard.php
@@ -182,7 +182,7 @@
  * ───────────────────────────────────────────────────────────────────────
  *
  * 1. Copy plugins/alfa-shipments/standard/ → plugins/alfa-shipments/fedex/
- * 2. Update namespace: Joomla\Plugin\AlfaShipments\FedEx\Extension
+ * 2. Update namespace: Alfa\Plugin\AlfaShipments\FedEx\Extension
  * 3. Rename class: final class FedEx extends ShipmentsPlugin
  * 4. Update services/provider.php
  *
@@ -206,7 +206,7 @@
  * @since  1.0.0
  */
 
-namespace Joomla\Plugin\AlfaShipments\Standard\Extension;
+namespace Alfa\Plugin\AlfaShipments\Standard\Extension;
 
 use Alfa\Component\Alfa\Administrator\Helper\OrderShipmentHelper;
 use Alfa\Component\Alfa\Administrator\Plugin\ShipmentsPlugin;

--- a/plugins/alfa-shipments/standard/standard.xml
+++ b/plugins/alfa-shipments/standard/standard.xml
@@ -12,7 +12,7 @@
 	<authorUrl>http://easylogic.gr</authorUrl>
 	<version>1.0.2</version>
 	<description>PLG_ALFA_SHIPMENTS_STANDARD_XML_DESCRIPTION</description>
-	<namespace path="src">Joomla\Plugin\AlfaShipments\Standard</namespace>
+	<namespace path="src">Alfa\Plugin\AlfaShipments\Standard</namespace>
 	<files>
 	    <folder>params</folder>
 		<folder plugin="standard">services</folder>


### PR DESCRIPTION
## What
Aligns the last plugins still using the `Joomla\Plugin\…` skeleton prefix with the project's `Alfa\` vendor convention (already used by the component, `system/alfasync`, `webservices/alfa`, and the add-on payment providers).

Renamed `Joomla\Plugin\Alfa*` → `Alfa\Plugin\Alfa*`:
- `alfa-shipments/standard`, `alfa-payments/standard`
- `alfa-fields/{text,textarea,tel,choice}`

Each rename touches only that plugin's own manifest `<namespace>`, `services/provider.php` `use`, `src/**` namespace lines, internal `FormHelper::addFieldPrefix()` strings, and form `addfieldprefix=` attrs. No folder renames.

## Safety
No com_alfa source references these plugin FQCNs (plugins resolve by group+element via the event/DI system), so the change is self-contained per plugin. All 17 changed PHP files pass `php -l`.

## Also
- `alfa.xml`: 1.1.0 → **1.2.0** (code-only refactor, no schema change → no `sql/updates` file)
- `.github/review-guidelines.md`: removed the premium-gateways/modules sentence from "Don't flag" (those ship CDN-only, not bundled by default)

Docs in Alfa-Commerce-Manual updated separately to document the `Alfa\` convention.